### PR TITLE
Fixed tp implementation for resistive mikromedia boards

### DIFF
--- a/api/tp/lib/src/tp/tp.c
+++ b/api/tp/lib/src/tp/tp.c
@@ -511,6 +511,10 @@ tp_process( tp_t * ctx )
         ctx->gesture_prev         = TP_EVENT_GEST_NONE;
         ctx->release              = TP_RELEASE_DET;
         ctx->touch_prev.n_touches = 0;
+        // For TSC2003 display there can be only 1 touch, so if display is not pressed, there are no touches.
+        #ifdef __TP_TSC2003__
+        ctx->touch.n_touches = 0;
+        #endif
     }
 
     return status;

--- a/changelog/v2.11.3/changelog.md
+++ b/changelog/v2.11.3/changelog.md
@@ -1,0 +1,29 @@
+<p align="center">
+  <img src="http://www.mikroe.com/img/designs/beta/logo_small.png?raw=true" alt="MikroElektronika"/>
+</p>
+
+---
+
+**[BACK TO MAIN FILE](../../changelog.md)**
+
+---
+
+# `v2.11.3`
+
++ released: TBD
+
+## Changes
+
+- [`v2.11.3`](#v2113)
+  - [Changes](#changes)
+    - [Fixes](#fixes)
+
+### Fixes
+
++ Fixed touch panel implementation and TSC2003 library to recognize touch on RESISTIVE displays while using LVGL projects
+
+---
+
+**[BACK TO MAIN FILE](../../changelog.md)**
+
+---

--- a/changelog/v2.11.3/changelog.md
+++ b/changelog/v2.11.3/changelog.md
@@ -10,7 +10,7 @@
 
 # `v2.11.3`
 
-+ released: TBD
++ released: 2024-10-01
 
 ## Changes
 
@@ -20,7 +20,8 @@
 
 ### Fixes
 
-+ Fixed touch panel implementation and TSC2003 library to recognize touch on RESISTIVE displays while using LVGL projects
++ Fixed touch panel implementation and TSC2003 library to recognize touch on TSC2003 RESISTIVE Displays while using LVGL projects
++ Fixed TP_ROTATION value to be "180" for all 4" CAPACITIVE Mikromedia Boards with PIC32MZ so touch position can be detected correctly
 
 ---
 

--- a/middleware/tsc2003/lib/src/tsc2003.c
+++ b/middleware/tsc2003/lib/src/tsc2003.c
@@ -148,7 +148,7 @@ tp_err_t tsc2003_process( tsc2003_t * ctx ) {
             }
         }
     } else {
-        ctx->press_det = (ctx->pen_down) ? (TP_EVENT_PRESS_DET) : (TP_EVENT_PRESS_NOT_DET);
+        ctx->press_det = TP_EVENT_PRESS_NOT_DET;
     }
 
     return TP_OK;


### PR DESCRIPTION
This PR is connected to #[SWMIKSDK-1697](https://jira.mikroe.com/browse/SWMIKSDK-1697)

Changes:

- [middleware/tsc2003/lib/src/tsc2003.c](https://github.com/MikroElektronika/mikrosdk_v2/blob/fix/touch_panel_resistive_tsc2003/middleware/tsc2003/lib/src/tsc2003.c)
    - removed pen pressure detection as it doesn't work with TSC2003
- [api/tp/lib/src/tp/tp.c](https://github.com/MikroElektronika/mikrosdk_v2/blob/fix/touch_panel_resistive_tsc2003/api/tp/lib/src/tp/tp.c)
    - added option to clear all the touches for TSC2003 specifically

Fixes:

- now touch is detected and cleared while using TSC2003 display with LVGL project
NOTE: STMPE approach for clearing touch inside the library itself doesn't work as it differs because it uses SPI - it sends the GPIO touch detection signal and then clears it even if we didn't release the pen whereas TSC is always sending GPIO touch detection signal until we stop touching the screen, so clearing of the touch should be done in tp.c.
