### PR TITLE
Fixed board/card update workflow.

### DIFF
--- a/.github/workflows/boardCardReleaseLive.yaml
+++ b/.github/workflows/boardCardReleaseLive.yaml
@@ -151,7 +151,7 @@ jobs:
         run: |
           if [[ ${{ steps.changelog_update.outputs.sdk_tag_name }} != "mikroSDK-0" ]]; then
             echo "Indexing to Live."
-            python -u scripts/index.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} ${{ steps.changelog_update.outputs.sdk_tag_name }} ${{ secrets.ES_INDEX_LIVE }} "False"
+            python -u scripts/index.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} ${{ steps.changelog_update.outputs.sdk_tag_name }} ${{ secrets.ES_INDEX_LIVE }} "False" "--board_card_only" "True"
           fi
 
       - name: Trigger database update in Core repo


### PR DESCRIPTION
This PR ensures only cards/boards are affected by appropriate workflow.

Additionally, it will speed the process up quite a bit.