### PR TITLE
Fixed new_hw.md file removal issue

### DIFF
--- a/.github/workflows/boardCardReleaseLive.yaml
+++ b/.github/workflows/boardCardReleaseLive.yaml
@@ -75,6 +75,16 @@ jobs:
           pip install packaging
           pip install alive-progress
 
+      - name: Check for new_hw.md file
+        id: check_new_hw_file
+        run: |
+          FILE_PATH="changelog/new_hw.md"
+          if [ -f "$FILE_PATH" ]; then
+            echo "new_hw_present=true" >> $GITHUB_OUTPUT
+          else
+            echo "new_hw_present=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update Changelogs
         id: changelog_update
         run: |
@@ -86,13 +96,11 @@ jobs:
           python -u scripts/log_changes.py
 
       - name: Remove original changelog file from git
+        if: ${{ steps.check_new_hw_file.outputs.new_hw_present == 'true' }}
         run: |
-          FILE_PATH="changelog/new_hw.md"
-          if [ -f "$FILE_PATH" ]; then
-            git rm changelog/new_hw.md
-            git commit -m "Remove old changelog file after moving it"
-            git push
-          fi
+          git rm changelog/new_hw.md
+          git commit -m "Remove old changelog file after moving it"
+          git push
 
       - name: Commit Changelog to current branch
         run: |


### PR DESCRIPTION
Issue occurred as the file checking was done after renaming it, so it was always false. Hence the file was never removed from git index.