### PR TITLE
Update checkIndexes.yaml

### DIFF
--- a/.github/workflows/checkIndexes.yaml
+++ b/.github/workflows/checkIndexes.yaml
@@ -13,7 +13,7 @@ on:
       regex:
         type: string
         description: Regex to use when searching for indexed items
-        default: "images_sdk|templates|mikrosdk|mcucard|mcu_card|click|mikromedia|pim|queries|sibrain|kit|board"
+        default: "images_sdk|templates|mikrosdk|easy|flip|mcucard|mcu_card|click|mikromedia|pim|queries|sibrain|kit|board"
       fix:
         type: boolean
         description: Fix the broken links with new ones?
@@ -27,7 +27,7 @@ on:
     - cron: "0/30 7-16 * * 1-5"  # Every 30 minutes, between 07:00 AM and 04:59 PM, Monday through Friday
 
 env:
-  GLOBAL_REGEX: "images_sdk|templates|mikrosdk|mcucard|mcu_card|click|mikromedia|pim|queries|sibrain|kit|board"
+  GLOBAL_REGEX: "images_sdk|templates|mikrosdk|easy|flip|mcucard|mcu_card|click|mikromedia|pim|queries|sibrain|kit|board"
 
 jobs:
   manual_run:


### PR DESCRIPTION
Packages like flip_and_click_pic32mz or easymx_pro_v7_for_tiva_mcu_card_with_tm4c129xnczad are not copied to DBP as in regex we define only the start of the package name and mcucard/click part of regex didn't affect these packages.

Leaving mcucard part of regex though just in case.
