### PR TITLE
STM32 UART implementation 1 fixed stop bit setting for UART4 and 5

### DIFF
--- a/changelog/v2.14.0/changelog.md
+++ b/changelog/v2.14.0/changelog.md
@@ -14,11 +14,13 @@
 
 ## Changes
 
-+ [`v2.14.0`](#v2140)
-  + [Changes](#changes)
-    + [New Features](#new-features)
-      + [mikroSDK](#mikrosdk)
-    + [NEW HARDWARE](#new-hardware)
+- [`v2.14.0`](#v2140)
+  - [Changes](#changes)
+    - [New Features](#new-features)
+      - [mikroSDK](#mikrosdk)
+    - [Fixes](#fixes)
+      - [mikroSDK](#mikrosdk-1)
+    - [NEW HARDWARE](#new-hardware)
 
 ### New Features
 
@@ -30,6 +32,14 @@
     + `hal_gpio_fetch_port`
   + Both functions defined as static inline inside main gpio header file for ease of use
   + For example, pin `GPIO_PC3` can be used to retrieve pin number as `3` and prot name as `GPIO_PORT_C`
+
+### Fixes
+
+#### mikroSDK
+
++ Corrected UART stop bit configuration for STM32
+  + The support for 0.5 and 1.5 stop bits on UART4 and UART5 for certain MCUs was previously overlooked
+  + This issue has now been addressed in the code
 
 ### NEW HARDWARE
 

--- a/targets/arm/mikroe/stm32/src/uart/implementation_1/hal_ll_uart.c
+++ b/targets/arm/mikroe/stm32/src/uart/implementation_1/hal_ll_uart.c
@@ -1251,8 +1251,39 @@ static uint32_t hal_ll_uart_get_clock_speed( hal_ll_pin_name_t module_index ) {
 static void hal_ll_uart_set_stop_bits_bare_metal( hal_ll_uart_hw_specifics_map_t *map ) {
     hal_ll_uart_base_handle_t *hal_ll_hw_reg = hal_ll_uart_get_base_struct(map->base);
 
-    switch ( map->stop_bit )
-    {
+    // 0.5 and 1.5 stop bits are not available for UART4 and UART5.
+    #if defined(UART_MODULE_4)
+    if ( hal_ll_uart_module_num( UART_MODULE_4 ) == map->module_index ) {
+        switch ( map->stop_bit ) {
+            case HAL_LL_UART_STOP_BITS_ONE:
+                hal_ll_hw_reg->cr2 |= STOP_BITS_ONE;
+                break;
+            case HAL_LL_UART_STOP_BITS_TWO:
+                hal_ll_hw_reg->cr2 |= STOP_BITS_TWO;
+                break;
+
+            default:
+                break;
+        }
+    }
+    #endif
+    #if defined(UART_MODULE_5)
+    if ( hal_ll_uart_module_num( UART_MODULE_5 ) == map->module_index ) {
+        switch ( map->stop_bit ) {
+            case HAL_LL_UART_STOP_BITS_ONE:
+                hal_ll_hw_reg->cr2 |= STOP_BITS_ONE;
+                break;
+            case HAL_LL_UART_STOP_BITS_TWO:
+                hal_ll_hw_reg->cr2 |= STOP_BITS_TWO;
+                break;
+
+            default:
+                break;
+        }
+    }
+    #endif
+
+    switch ( map->stop_bit ) {
         case HAL_LL_UART_STOP_BITS_HALF:
             hal_ll_hw_reg->cr2 |= STOP_BITS_HALF;
             break;

--- a/targets/arm/mikroe/stm32/src/uart/implementation_1/hal_ll_uart.c
+++ b/targets/arm/mikroe/stm32/src/uart/implementation_1/hal_ll_uart.c
@@ -67,6 +67,11 @@ static volatile hal_ll_uart_handle_register_t hal_ll_module_state[UART_MODULE_CO
 #define hal_ll_uart_get_baud(_clock,_baud,_div) (((_clock/(float)_baud)/_div)-1)
 #define hal_ll_uart_get_real_baud(_clock,_baud,_div) (_clock/(_div*(_baud+1)))
 #define hal_ll_uart_get_baud_error(_baud_real,_baud) (((float)(abs(_baud_real-_baud))/_baud)*100)
+#define hal_ll_uart_check_stop_bit_availability(module_number,uart4_or_uart5,stop_bits_select) \
+        if( module_number == uart4_or_uart5 && \
+           ( HAL_LL_UART_STOP_BITS_HALF == stop_bits_select || \
+             HAL_LL_UART_STOP_BITS_ONE_AND_A_HALF == stop_bits_select )) \
+            return HAL_LL_UART_ERROR;
 
 /*!< @brief Macros defining bit location */
 #if defined(STM32F4xx) || defined(STM32F2xx)
@@ -587,6 +592,14 @@ hal_ll_err_t hal_ll_uart_set_parity( handle_t *handle, hal_ll_uart_parity_t pari
 hal_ll_err_t hal_ll_uart_set_stop_bits( handle_t *handle, hal_ll_uart_stop_bits_t stop_bit ) {
     low_level_handle = hal_ll_uart_get_handle;
     hal_ll_uart_hw_specifics_map_local = hal_ll_get_specifics(hal_ll_uart_get_module_state_address);
+
+    // 0.5 and 1.5 stop bits are not available for UART4 and UART5.
+    #ifdef UART_MODULE_4
+    hal_ll_uart_check_stop_bit_availability(hal_ll_uart_hw_specifics_map_local->module_index, UART_MODULE_4, stop_bit)
+    #endif
+    #ifdef UART_MODULE_5
+    hal_ll_uart_check_stop_bit_availability(hal_ll_uart_hw_specifics_map_local->module_index, UART_MODULE_5, stop_bit)
+    #endif
 
     low_level_handle->init_ll_state = false;
 
@@ -1250,38 +1263,6 @@ static uint32_t hal_ll_uart_get_clock_speed( hal_ll_pin_name_t module_index ) {
 
 static void hal_ll_uart_set_stop_bits_bare_metal( hal_ll_uart_hw_specifics_map_t *map ) {
     hal_ll_uart_base_handle_t *hal_ll_hw_reg = hal_ll_uart_get_base_struct(map->base);
-
-    // 0.5 and 1.5 stop bits are not available for UART4 and UART5.
-    #if defined(UART_MODULE_4)
-    if ( hal_ll_uart_module_num( UART_MODULE_4 ) == map->module_index ) {
-        switch ( map->stop_bit ) {
-            case HAL_LL_UART_STOP_BITS_ONE:
-                hal_ll_hw_reg->cr2 |= STOP_BITS_ONE;
-                break;
-            case HAL_LL_UART_STOP_BITS_TWO:
-                hal_ll_hw_reg->cr2 |= STOP_BITS_TWO;
-                break;
-
-            default:
-                break;
-        }
-    }
-    #endif
-    #if defined(UART_MODULE_5)
-    if ( hal_ll_uart_module_num( UART_MODULE_5 ) == map->module_index ) {
-        switch ( map->stop_bit ) {
-            case HAL_LL_UART_STOP_BITS_ONE:
-                hal_ll_hw_reg->cr2 |= STOP_BITS_ONE;
-                break;
-            case HAL_LL_UART_STOP_BITS_TWO:
-                hal_ll_hw_reg->cr2 |= STOP_BITS_TWO;
-                break;
-
-            default:
-                break;
-        }
-    }
-    #endif
 
     switch ( map->stop_bit ) {
         case HAL_LL_UART_STOP_BITS_HALF:


### PR DESCRIPTION
This PR is connected to [issue](https://jira.mikroe.com/browse/SWMIKSDK-1475)

Changes:

- STM32 UART implementation 1: Stop bits 0.5 and 1.5 can no longer be set for modules 4 and 5
