### PR TITLE
Changed the type (and size) of return variables from uint8_t to hal_ll_err_t

### DIFF
--- a/changelog/v2.14.0/changelog.md
+++ b/changelog/v2.14.0/changelog.md
@@ -14,11 +14,13 @@
 
 ## Changes
 
-+ [`v2.14.0`](#v2140)
-  + [Changes](#changes)
-    + [New Features](#new-features)
-      + [mikroSDK](#mikrosdk)
-    + [NEW HARDWARE](#new-hardware)
+- [`v2.14.0`](#v2140)
+  - [Changes](#changes)
+    - [New Features](#new-features)
+      - [mikroSDK](#mikrosdk)
+    - [Fixes](#fixes)
+      - [mikroSDK](#mikrosdk-1)
+    - [NEW HARDWARE](#new-hardware)
 
 ### New Features
 
@@ -30,6 +32,14 @@
     + `hal_gpio_fetch_port`
   + Both functions defined as static inline inside main gpio header file for ease of use
   + For example, pin `GPIO_PC3` can be used to retrieve pin number as `3` and prot name as `GPIO_PORT_C`
+
+### Fixes
+
+#### mikroSDK
+
++ Updated low-level I2C implementation
+  + Some of the return value variables were originally declared as 8-bit, but they needed to handle larger values
+  + This has now been fixed
 
 ### NEW HARDWARE
 

--- a/targets/arm/mikroe/nxp/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/arm/mikroe/nxp/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -862,7 +862,7 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
 static hal_ll_err_t hal_ll_i2c_master_start( hal_ll_i2c_hw_specifics_map_t *map ) {
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     uint16_t time_counter = map->timeout;
-    uint8_t status = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t status = HAL_LL_I2C_MASTER_SUCCESS;
 
     status = hal_ll_i2c_master_wait_for_idle( map );
     if ( HAL_LL_I2C_MASTER_SUCCESS != status ){

--- a/targets/arm/mikroe/sam/src/i2c/implementations/implementation_1/hal_ll_i2c_master.c
+++ b/targets/arm/mikroe/sam/src/i2c/implementations/implementation_1/hal_ll_i2c_master.c
@@ -535,7 +535,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     uint16_t time_counter = map->timeout;
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
     uint8_t dummy_data;
 
     #ifdef __TFT_RESISTIVE_TSC2003__
@@ -595,7 +595,7 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     uint16_t time_counter = map->timeout;
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
 
     hal_ll_i2c_master_configure_transfer( hal_ll_hw_reg, map->address, false );
 

--- a/targets/arm/mikroe/stm32/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/arm/mikroe/stm32/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -577,7 +577,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
     uint16_t time_counter = map->timeout;
     size_t transfer_counter = 0;
     volatile uint32_t status_reg_clear;
-    uint8_t status = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t status = HAL_LL_I2C_MASTER_SUCCESS;
 
     if( mode != HAL_LL_I2C_MASTER_WRITE_THEN_READ ) {
         status = hal_ll_i2c_master_start( map );
@@ -700,7 +700,7 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     uint16_t time_counter = map->timeout;
     size_t transfer_counter = 0;
-    uint8_t status = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t status = HAL_LL_I2C_MASTER_SUCCESS;
 
     status = hal_ll_i2c_master_start( map );
     if( status != HAL_LL_I2C_MASTER_SUCCESS ) {
@@ -767,7 +767,7 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
 static hal_ll_err_t hal_ll_i2c_master_start( hal_ll_i2c_hw_specifics_map_t *map ) {
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     uint16_t time_counter = map->timeout;
-    uint8_t result = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t result = HAL_LL_I2C_MASTER_SUCCESS;
 
     result = hal_ll_i2c_master_wait_for_idle( map );
     if ( result != HAL_LL_I2C_MASTER_SUCCESS )
@@ -788,7 +788,7 @@ static hal_ll_err_t hal_ll_i2c_master_start( hal_ll_i2c_hw_specifics_map_t *map 
     return HAL_LL_I2C_MASTER_SUCCESS;
 }
 
-static uint8_t hal_ll_i2c_master_wait_for_idle( hal_ll_i2c_hw_specifics_map_t *map ) {
+static hal_ll_err_t hal_ll_i2c_master_wait_for_idle( hal_ll_i2c_hw_specifics_map_t *map ) {
     uint16_t time_counter = map->timeout;
 
     while ( !hal_ll_i2c_master_is_idle( map->base ) ) {

--- a/targets/arm/mikroe/stm32/src/i2c/implementation_2/hal_ll_i2c_master.c
+++ b/targets/arm/mikroe/stm32/src/i2c/implementation_2/hal_ll_i2c_master.c
@@ -665,7 +665,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     uint16_t time_counter = map->timeout;
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
 
     /**
      * @note When R/W = 0, the input sample acquisition period starts
@@ -713,7 +713,7 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     uint16_t time_counter = map->timeout;
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
 
     hal_ll_i2c_master_configure_transfer ( map->base,
                                          ( map->address << 1 & HAL_LL_I2C_CR2_SADD ) |

--- a/targets/arm/mikroe/tiva/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/arm/mikroe/tiva/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -551,7 +551,7 @@ void hal_ll_i2c_master_close( handle_t *handle ) {
 static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *write_data_buf, size_t len_write_data, hal_ll_i2c_master_end_mode_t mode ){
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     uint16_t time_counter = map->timeout;
-    uint8_t result = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t result = HAL_LL_I2C_MASTER_SUCCESS;
     size_t i = 2;
 
     result = hal_ll_i2c_master_wait_for_idle( map );
@@ -659,7 +659,6 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
 static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *read_data_buf, size_t len_read_data, hal_ll_i2c_master_end_mode_t mode ){
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     uint16_t time_counter = map->timeout;
-    uint8_t result = HAL_LL_I2C_MASTER_SUCCESS;
     size_t i = 1;
 
     hal_ll_hw_reg->msa = map->address << 1 | 0x1;

--- a/targets/pic_16bit/mikroe/dspic/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/pic_16bit/mikroe/dspic/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -582,7 +582,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
     const hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     size_t transfer_counter = 0;
     uint16_t time_counter = map->timeout;
-    uint8_t status = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t status = HAL_LL_I2C_MASTER_SUCCESS;
 
     if ( HAL_LL_I2C_MASTER_WRITE_THEN_READ != mode ) {
         status = hal_ll_i2c_master_start( map );
@@ -638,7 +638,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
 static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *write_data_buf, size_t len_write_data, hal_ll_i2c_master_end_mode_t mode ) {
     const hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     size_t transfer_counter = 0;
-    uint8_t status = HAL_LL_I2C_MASTER_SUCCESS;
+    hal_ll_err_t status = HAL_LL_I2C_MASTER_SUCCESS;
 
     status = hal_ll_i2c_master_start( map );
     if ( HAL_LL_I2C_MASTER_SUCCESS != status ) {

--- a/targets/pic_32bit/mikroe/pic32/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/pic_32bit/mikroe/pic32/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -566,7 +566,7 @@ void hal_ll_i2c_master_close( handle_t *handle ) {
 static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *write_data_buf, size_t len_write_data, hal_ll_i2c_master_end_mode_t mode ) {
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
     uint16_t time_counter = map->timeout;
 
     status = hal_ll_i2c_master_start( map );
@@ -629,7 +629,7 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
 static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *read_data_buf, size_t len_read_data, hal_ll_i2c_master_end_mode_t mode ){
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct( map->base );
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
     uint16_t time_counter = map->timeout;
 
     if( HAL_LL_I2C_MASTER_WRITE_THEN_READ != mode ) {

--- a/targets/pic_8bit/mikroe/pic18/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/pic_8bit/mikroe/pic18/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -647,7 +647,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
     const hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     size_t transfer_counter = NULL;
     uint16_t time_counter = map->timeout;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
 
     if( mode != HAL_LL_I2C_MASTER_WRITE_THEN_READ ) {
         status = hal_ll_i2c_master_start( map );
@@ -705,7 +705,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
 static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *write_data_buf, size_t len_write_data, hal_ll_i2c_master_end_mode_t mode ) {
     const hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
 
     status = hal_ll_i2c_master_start( map );
     if( status != HAL_LL_I2C_MASTER_SUCCESS ) {

--- a/targets/pic_8bit/mikroe/pic18/src/i2c/implementation_2/hal_ll_i2c_master.c
+++ b/targets/pic_8bit/mikroe/pic18/src/i2c/implementation_2/hal_ll_i2c_master.c
@@ -610,7 +610,7 @@ void hal_ll_i2c_master_close( handle_t *handle ) {
 static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *read_data_buf, size_t len_read_data, hal_ll_i2c_master_end_mode_t mode ) {
     const hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     size_t transfer_counter = NULL;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
     uint16_t time_counter = map->timeout;
 
     if( !check_reg_bit( hal_ll_hw_reg->i2c_con0_reg_addr, HAL_LL_I2C_MASTER_MDR_BIT ) ) {
@@ -682,7 +682,7 @@ static hal_ll_err_t hal_ll_i2c_master_read_bare_metal( hal_ll_i2c_hw_specifics_m
 static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_map_t *map, uint8_t *write_data_buf, size_t len_write_data, hal_ll_i2c_master_end_mode_t mode ) {
     const hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     uint16_t time_counter = map->timeout;
-    uint8_t status = NULL;
+    hal_ll_err_t status = NULL;
     size_t transfer_counter = NULL;
 
     if( !check_reg_bit( hal_ll_hw_reg->i2c_con0_reg_addr, HAL_LL_I2C_MASTER_MDR_BIT ) ) {

--- a/targets/riscv/mikroe/gigadevice/src/i2c/implementation_1/hal_ll_i2c_master.c
+++ b/targets/riscv/mikroe/gigadevice/src/i2c/implementation_1/hal_ll_i2c_master.c
@@ -623,7 +623,6 @@ static hal_ll_err_t hal_ll_i2c_master_write_bare_metal( hal_ll_i2c_hw_specifics_
 static hal_ll_err_t hal_ll_i2c_master_start( hal_ll_i2c_hw_specifics_map_t *map ) {
     hal_ll_i2c_base_handle_t *hal_ll_hw_reg = hal_ll_i2c_get_base_struct(map->base);
     uint16_t time_counter = map->timeout;
-    uint8_t result = HAL_LL_I2C_MASTER_SUCCESS;
 
     set_reg_bit( &( hal_ll_hw_reg->ctl0 ), HAL_LL_I2C_CTL0_START_BIT );
 


### PR DESCRIPTION
This PR is connected to https://jira.mikroe.com/browse/SWMIKSDK-1410

Fixed the size of return value where it used to be 8 bit but is supposed to hold up to 12 bit values