### PR TITLE
Changed MCU card info to show Flash size in Bytes

### DIFF
--- a/scripts/add_extra_index_info.py
+++ b/scripts/add_extra_index_info.py
@@ -168,7 +168,7 @@ def form_extra_information(asset_type, package_name, asset_url, token):
             'extra_information' :
                 {
                     'RAM Size' : f'{ram_size} KB',
-                    'Flash Size' : f'{flash_size} KB',
+                    'Flash Size' : f'{flash_size} B',
                     'Maximum Speed' : f'{max_speed} MHz',
                     'Core Name' : core_name,
                     'Pin Count': pin_num,

--- a/scripts/add_extra_index_info.py
+++ b/scripts/add_extra_index_info.py
@@ -116,6 +116,13 @@ def get_card_info_from_db(db_path, device_name):
         ram_int = int(ram) / 1024
         ram = str(ram_int)
 
+        # Process Flash value to display it in KB or B
+        if int(flash) >= 1024:
+            flash_int = int(flash) / 1024
+            flash = str(flash_int) + " KB"
+        else:
+            flash = flash + " B"
+
         # Query to get package_uid
         cursor.execute("""
             SELECT DISTINCT package_uid
@@ -168,7 +175,7 @@ def form_extra_information(asset_type, package_name, asset_url, token):
             'extra_information' :
                 {
                     'RAM Size' : f'{ram_size} KB',
-                    'Flash Size' : f'{flash_size} B',
+                    'Flash Size' : flash_size,
                     'Maximum Speed' : f'{max_speed} MHz',
                     'Core Name' : core_name,
                     'Pin Count': pin_num,


### PR DESCRIPTION
As from this release we are storing Flash size in the database in Bytes and we are showing in NECTO Flash size in bytes as well, we need to update the flash info obtaining from the database for MCU Cards as well.