### PR TITLE
UART & logger set to have interrupt approach by default 

### DIFF
--- a/api/log/lib/include/uart/log.h
+++ b/api/log/lib/include/uart/log.h
@@ -97,6 +97,7 @@ typedef struct
     hal_pin_name_t rx_pin;
     hal_pin_name_t tx_pin;
     uint32_t baud;
+    bool is_interrupt;
     log_level_t level;
 } log_cfg_t;
 
@@ -124,6 +125,7 @@ typedef struct
     cfg.rx_pin = MIKROBUS(mikrobus, MIKROBUS_RX); \
     cfg.tx_pin = MIKROBUS(mikrobus, MIKROBUS_TX); \
     cfg.baud = 115200; \
+    cfg.is_interrupt = true; \
     cfg.level = LOG_LEVEL_DEBUG;
 
 /*!

--- a/api/log/lib/src/uart/log.c
+++ b/api/log/lib/src/uart/log.c
@@ -67,6 +67,7 @@ log_err_t log_init ( log_t *log, log_cfg_t *cfg )
     // UART module config
     uart_cfg.rx_pin = cfg->rx_pin;  // UART RX pin.
     uart_cfg.tx_pin = cfg->tx_pin;  // UART TX pin.
+    uart_cfg.is_interrupt = cfg->is_interrupt;
     uart_cfg.tx_ring_size = sizeof( uart_tx_buf );
     uart_cfg.rx_ring_size = sizeof( uart_rx_buf );
 

--- a/changelog/v2.14.2/changelog.md
+++ b/changelog/v2.14.2/changelog.md
@@ -1,0 +1,42 @@
+<p align="center">
+  <img src="http://www.mikroe.com/img/designs/beta/logo_small.png?raw=true" alt="MikroElektronika"/>
+</p>
+
+---
+
+**[BACK TO MAIN FILE](../../changelog.md)**
+
+---
+
+# `v2.14.2`
+
++ released: 2025-03-12
+
+## Changes
+
++ [`v2.14.2`](#v2142)
+  + [Changes](#changes)
+    + [Fixes](#fixes)
+      + [mikroSDK](#mikrosdk)
+    + [NEW HARDWARE](#new-hardware)
+
+### Fixes
+
+#### mikroSDK
+
++ Set UART configuration to use interrupt-based approach by default
+
+### NEW HARDWARE
+
+> NOTE:
+>> If any new hardware was added to current version, it will be listed here.
+
+Support added for following hardware:
+
++ **[2025-03-11](./new_hw/2025-03-11.md)**
+
+---
+
+**[BACK TO MAIN FILE](../../changelog.md)**
+
+---

--- a/changelog/v2.14.2/changelog.md
+++ b/changelog/v2.14.2/changelog.md
@@ -25,6 +25,7 @@
 #### mikroSDK
 
 + Set UART configuration to use interrupt-based approach by default
+  + Applied to both UART and logger for consistency across all projects
 
 ### NEW HARDWARE
 

--- a/changelog/v2.14.2/new_hw/2025-03-11.md
+++ b/changelog/v2.14.2/new_hw/2025-03-11.md
@@ -1,0 +1,29 @@
+<p align="center">
+  <img src="http://www.mikroe.com/img/designs/beta/logo_small.png?raw=true" alt="MikroElektronika"/>
+</p>
+
+---
+
+**[BACK TO PREVIOUS FILE](../changelog.md)**
+
+---
+
+# 2025-03-11
+
+## Changes
+
+- [2025-03-11](#2025-03-11)
+  - [Changes](#changes)
+    - [NEW HARDWARE](#new-hardware)
+
+### NEW HARDWARE
+
+Support added for following hardware:
+
++ [AUTOMOTIVE NETWORKING DEVELOPMENT BOARD](https://www.microchip.com/en-us/development-tool/ADM00716)
+
+---
+
+**[BACK TO PREVIOUS FILE](../changelog.md)**
+
+---

--- a/drv/lib/include/drv_uart.h
+++ b/drv/lib/include/drv_uart.h
@@ -149,6 +149,8 @@ typedef struct
 
     size_t tx_ring_size; /*!< Tx ring size. */
     size_t rx_ring_size; /*!< Rx ring size. */
+
+    bool is_interrupt; /*!< Choose between interrupt and polling. */
 } uart_config_t;
 
 /**
@@ -174,7 +176,6 @@ typedef struct
     bool is_rx_irq_enabled; /*!< Rx interrupt enabled. */
 
     bool is_blocking; /*!< Is blocking. */
-    bool is_interrupt; /*!< Choose between interrupt and polling. */
 } uart_t;
 
 /*!

--- a/drv/lib/src/lib_drv_uart/drv_uart.c
+++ b/drv/lib/src/lib_drv_uart/drv_uart.c
@@ -115,6 +115,8 @@ void uart_configure_default( uart_config_t *config )
 
         config->tx_ring_size = 0;
         config->rx_ring_size = 0;
+
+        config->is_interrupt = true;
     }
 }
 
@@ -313,7 +315,7 @@ err_t uart_write( uart_t *obj, uint8_t *buffer, size_t size )
         if ( hal_handle->init_state == false )
             hal_ll_module_configure_uart( (handle_t *)&hal_handle );
 
-        if ( obj->is_interrupt ) {
+        if ( obj->config.is_interrupt ) {
             while ( data_written < size )
             {
                 if ( ring_buf8_is_full( ring ) )
@@ -446,7 +448,7 @@ err_t uart_read( uart_t *obj, uint8_t *buffer, size_t size )
         if ( hal_handle->init_state == false )
             hal_ll_module_configure_uart( (handle_t *)&hal_handle );
 
-        if ( obj->is_interrupt ) {
+        if ( obj->config.is_interrupt ) {
             // Enable module interrupt, if it's disabled
             if ( !hal_obj->is_rx_irq_enabled )
             {

--- a/hal/lib/include/hal_uart.h
+++ b/hal/lib/include/hal_uart.h
@@ -176,6 +176,8 @@ typedef struct
 
     size_t tx_ring_size; /*!< Tx ring size. */
     size_t rx_ring_size; /*!< Rx ring size. */
+
+    bool is_interrupt; /*!< Choose between interrupt and polling. */
 } hal_uart_config_t;
 
 /**
@@ -201,7 +203,6 @@ typedef struct
     bool is_rx_irq_enabled; /*!< Rx interrupt enabled. */
 
     bool is_blocking; /*!< Is blocking. */
-    bool is_interrupt; /*!< Choose between interrupt and polling. */
 } hal_uart_t;
 
 /*!

--- a/tests/uart/test_example/main.c
+++ b/tests/uart/test_example/main.c
@@ -88,7 +88,7 @@ int main( void ) {
 
     // Choose UART mode: Set to `true` for
     // interrupt-driven UART, `false` for polling mode.
-    uart.is_interrupt = false;
+    uart_cfg.is_interrupt = false;
 
     // TODO Test different set of pins.
     // Make sure to test higher nibble pins, ie. pins


### PR DESCRIPTION
Set UART configuration to use interrupt-based approach by default

Changes:

- uart log
- uart drv and hal
- uart test
