### PR TITLE
Updated workflow to release board specific clocks

### DIFF
--- a/.github/workflows/boardCardReleaseLive.yaml
+++ b/.github/workflows/boardCardReleaseLive.yaml
@@ -15,6 +15,10 @@ on:
         type: boolean
         description: If checked, mikroe bot will notify mattermost channel with release details.
         default: false
+      clock_release:
+        type: boolean
+        description: Release the clock for this board? (branch with the same name as for board release should be present in core_packages and contain schema file for the board)
+        default: false
 
 jobs:
   upload_board_assets_live:
@@ -109,6 +113,13 @@ jobs:
           git commit -m "Updated changelog files with latest release info."
           git push
 
+      - name: Commit bsp header to current branch
+        run: |
+          echo "Updating with new bsp header changes";
+          git add bsp/**
+          git commit -m "Updated bsp header files with latest release info."
+          git push
+
       # Create a pull request using the GitHub API
       - name: Create Pull Request
         id: create_pr
@@ -162,7 +173,7 @@ jobs:
             python -u scripts/index.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} ${{ steps.changelog_update.outputs.sdk_tag_name }} ${{ secrets.ES_INDEX_LIVE }} "False"
           fi
 
-      - name: Trigger database update in Core repo
+      - name: Trigger database and schemas update in Core repo
         run: |
           if [[ ${{ steps.changelog_update.outputs.sdk_tag_name }} != "mikroSDK-0" ]]; then
             # Set the required variables
@@ -171,13 +182,20 @@ jobs:
             event_type="trigger-workflow-update-database-from-sdk"
             version="${{ steps.changelog_update.outputs.sdk_tag_name }}"
 
+            # Specify the branch name for schema fetching
+            if [ "${{ github.event.inputs.clock_release }}" = "true" ]; then
+              branch="${{ github.event.inputs.release_branch }}"
+            else
+              branch="main"
+            fi
+
             curl -L \
               -X POST \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ secrets.MIKROE_ACTIONS_KEY }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-              -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"index\": \"Live\", \"unit\": false, \"integration\": true}}"
+              -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"index\": \"Live\", \"unit\": false, \"integration\": true, \"branch\":\"$branch\"}}"
           fi
 
       - name: Build Message with Python

--- a/.github/workflows/boardCardReleaseTest.yaml
+++ b/.github/workflows/boardCardReleaseTest.yaml
@@ -7,6 +7,10 @@ on:
         type: string
         description: Which Branch to release Boards from? (change last number to desired number)
         default: "new-feature/boards_and_cards/1"
+      clock_release:
+        type: boolean
+        description: Release the clock for this board? (branch with the same name as for board release should be present in core_packages and contain schema file for the board)
+        default: false
 
 jobs:
   upload_board_assets_dev:
@@ -39,6 +43,7 @@ jobs:
         run: git fetch origin master
 
       - name: Merge Master into ${{ github.event.inputs.release_branch }}
+        if: ${{ github.event.inputs.clock_release == 'false' }} # For clock release we usually update existing bsp header with changelog info, so there will be merge conflict
         run: |
           git merge origin/master --allow-unrelated-histories
           # Check if there are changes to commit after the merge
@@ -104,7 +109,7 @@ jobs:
           echo "Indexing to Test."
           python -u scripts/index.py ${{ github.repository }} ${{ secrets.GITHUB_TOKEN }} ${{ steps.changelog_update.outputs.sdk_tag_name }} ${{ secrets.ES_INDEX_TEST }} "False"
 
-      - name: Trigger database update in Core repo
+      - name: Trigger database and schemas update in Core repo
         run: |
           # Set the required variables
           repo_owner="MikroElektronika"
@@ -112,13 +117,20 @@ jobs:
           event_type="trigger-workflow-update-database-from-sdk"
           version="${{ steps.changelog_update.outputs.sdk_tag_name }}"
 
+          # Specify the branch name for schema fetching
+          if [ "${{ github.event.inputs.clock_release }}" = "true" ]; then
+            branch="${{ github.event.inputs.release_branch }}"
+          else
+            branch="main"
+          fi
+
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.MIKROE_ACTIONS_KEY }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"index\": \"Test\", \"unit\": false, \"integration\": true}}"
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"index\": \"Test\", \"unit\": false, \"integration\": true, \"branch\":\"$branch\"}}"
 
       - name: Notify Mattermost - Test ready
         env:

--- a/.github/workflows/triggerDBUpdate.yaml
+++ b/.github/workflows/triggerDBUpdate.yaml
@@ -34,4 +34,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.MIKROE_ACTIONS_KEY }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/$repo_owner/$repo_name/dispatches \
-            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"index\": \"${{ github.event.inputs.database_version }}\", \"unit\": false, \"integration\": true}}"
+            -d "{\"event_type\": \"$event_type\", \"client_payload\": {\"version\": \"$version\", \"index\": \"${{ github.event.inputs.database_version }}\", \"unit\": false, \"integration\": true, \"branch\":\"$branch\"}}"

--- a/scripts/build_message.py
+++ b/scripts/build_message.py
@@ -40,7 +40,6 @@ def extract_new_hardware_from_md(md_file_path_or_url):
         string_out = 'Preconfigured Clock settings addeded for following hardware:\n'
         pattern = re.compile(r'### Improvements\s+Preconfigured Clock settings added for following hardware:(.*?)---', re.DOTALL)
         match = pattern.search(content)
-
     if match:
         # Extracted section (it's a block of text, including newlines)
         new_hardware_section = match.group(1).strip()

--- a/scripts/build_message.py
+++ b/scripts/build_message.py
@@ -40,6 +40,7 @@ def extract_new_hardware_from_md(md_file_path_or_url):
         string_out = 'Preconfigured Clock settings addeded for following hardware:\n'
         pattern = re.compile(r'### Improvements\s+Preconfigured Clock settings added for following hardware:(.*?)---', re.DOTALL)
         match = pattern.search(content)
+
     if match:
         # Extracted section (it's a block of text, including newlines)
         new_hardware_section = match.group(1).strip()

--- a/scripts/build_message.py
+++ b/scripts/build_message.py
@@ -35,8 +35,13 @@ def extract_new_hardware_from_md(md_file_path_or_url):
     # Regular expression to capture the "NEW HARDWARE" section
     pattern = re.compile(r'### NEW HARDWARE\s+Support added for following hardware:(.*?)---', re.DOTALL)
     match = pattern.search(content)
-
     string_out = ''
+    if not match:
+        string_out = 'Preconfigured Clock settings addeded for following hardware:\n'
+        pattern = re.compile(r'### Improvements\s+Preconfigured Clock settings added for following hardware:(.*?)---', re.DOTALL)
+        match = pattern.search(content)
+
+
     if match:
         # Extracted section (it's a block of text, including newlines)
         new_hardware_section = match.group(1).strip()

--- a/scripts/build_message.py
+++ b/scripts/build_message.py
@@ -41,7 +41,6 @@ def extract_new_hardware_from_md(md_file_path_or_url):
         pattern = re.compile(r'### Improvements\s+Preconfigured Clock settings added for following hardware:(.*?)---', re.DOTALL)
         match = pattern.search(content)
 
-
     if match:
         # Extracted section (it's a block of text, including newlines)
         new_hardware_section = match.group(1).strip()

--- a/scripts/build_message_web.py
+++ b/scripts/build_message_web.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
             # Find newly published SDK packages
             if sdk_file['published_at'].startswith(current_date):
                 # Check if it is a newly released package that is listed in release spreadsheet
-                if sdk_file['display_name'] in release_spreadsheet_data:
+                if sdk_file['display_name'] in release_spreadsheet_data and 'Clock' not in release_spreadsheet_data:
                     if sdk_file['type'] == 'mcu':
                         # Separate MCU packages to display them before boards and cards
                         mcu_lines += f'\t<li>{sdk_file['display_name']}</li>\n'
@@ -162,12 +162,20 @@ if __name__ == '__main__':
                         todays_release = todays_release.replace('</ul>', f'\t<li>{sdk_file['display_name']}</li>\n</ul>')
                 # If it is not newly released package - add it to UPDATED section
                 else:
-                    if sdk_file['type'] == 'card':
-                        todays_update = todays_update.replace('</ul>', f'\t<li>Card Package for {sdk_file['display_name']}</li>\n</ul>')
-                    elif sdk_file['type'] == 'board':
-                        todays_update = todays_update.replace('</ul>', f'\t<li>Board Package for {sdk_file['display_name']}</li>\n</ul>')
+                    if 'Clock' not in release_spreadsheet_data:
+                        if sdk_file['type'] == 'card':
+                            todays_update = todays_update.replace('</ul>', f'\t<li>Card Package for {sdk_file['display_name']}</li>\n</ul>')
+                        elif sdk_file['type'] == 'board':
+                            todays_update = todays_update.replace('</ul>', f'\t<li>Board Package for {sdk_file['display_name']}</li>\n</ul>')
+                        else:
+                            todays_update = todays_update.replace('</ul>', f'\t<li>{sdk_file['display_name']}</li>\n</ul>')
                     else:
-                        todays_update = todays_update.replace('</ul>', f'\t<li>{sdk_file['display_name']}</li>\n</ul>')
+                        if sdk_file['type'] == 'card':
+                            todays_update = todays_update.replace('</ul>', f'\t<li>Clock preset for {sdk_file['display_name']}</li>\n</ul>')
+                        elif sdk_file['type'] == 'board':
+                            todays_update = todays_update.replace('</ul>', f'\t<li>Clock preset for {sdk_file['display_name']}</li>\n</ul>')
+                        else:
+                            todays_update = todays_update.replace('</ul>', f'\t<li>{sdk_file['display_name']}</li>\n</ul>')
                     update_present = 1
 
     # Workaround to display mikroSDK as updated package although it is in the spreadsheet

--- a/scripts/update_board_changelog.py
+++ b/scripts/update_board_changelog.py
@@ -57,7 +57,7 @@ def edit_changelog(version):
         write_output_to_file(os.path.join(os.getcwd(), 'sdk_tag.txt'), version)
 
         # Return prettyfied local path to the changelog file for this release to use it in bsp header
-        return os.path.join(file_dir, f'v{version}', f'new_hw/{current_date}.md').replace('\\', '/').split('changelog/')[1]
+        return os.path.join(file_dir, f'v{version}', f'new_hw/{current_date}.md').replace(os.sep, '/').split('changelog/')[1]
     else:
         # Extract and sort versions, removing the 'v' prefix
         # Take the highest version present in the repo itself, not github


### PR DESCRIPTION
General idea of this update is to modify bsp header files with placeholders for changelog with spcific changelog markdown path so board is displayed as an update in NECTO Studio.

Then trigger schema and database update in core_packages repo on the dedicated branch. This way boards will be released/updated with clock from now on.