### PR TITLE
Toshiba SPI configuration issue fixes

### DIFF
--- a/targets/arm/mikroe/toshiba/include/hal_ll_cg.h
+++ b/targets/arm/mikroe/toshiba/include/hal_ll_cg.h
@@ -84,6 +84,25 @@ typedef struct {
     uint32_t spclken;      // 0x4008305C - Clock Supply and Stop Register for ADC and Debug Circuit
 } hal_ll_cg_base_handle_t;
 
+typedef struct
+{
+    uint32_t CG_FC_Frequency;       // System frequency.
+    uint32_t CG_FSYSH_Frequency;    // High-speed system clock.
+    uint32_t CG_FSYSM_Frequency;    // Middle-speed system clock.
+    uint32_t CG_FT0H_Frequency;     // High-speed system prescaler clock.
+    uint32_t CG_FT0M_Frequency;     // Middle-speed system prescaler clock.
+} CG_ClocksTypeDef;
+
+
+/**
+ * @brief Gets clock values.
+ *
+ * @param CG_Clocks [OUT] Clock values structure.
+ *
+ * @return *CG_Clocks Structure containing clock values.
+ */
+void CG_GetClocksFrequency( CG_ClocksTypeDef *CG_Clocks );
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/arm/mikroe/toshiba/include/hal_ll_cg.h
+++ b/targets/arm/mikroe/toshiba/include/hal_ll_cg.h
@@ -93,7 +93,6 @@ typedef struct
     uint32_t CG_FT0M_Frequency;     // Middle-speed system prescaler clock.
 } CG_ClocksTypeDef;
 
-
 /**
  * @brief Gets clock values.
  *


### PR DESCRIPTION
# SPI Configuration Improvements for Toshiba TMPM4K MCU - lmrt-SPI Branch

## SPI Configuration Issue Fixes (Commit: 5e05bff6)
**Date:** September 10, 2025   
**Description:** SPI configuration issue fixes

## Key Changes Analysis

### 1. Clock Generator Enhancement
**File:** `targets/arm/mikroe/toshiba/include/hal_ll_cg.h`

**Changes:**
- **Added new clock structure** `CG_ClocksTypeDef` for dynamic clock frequency management:
  - `CG_FC_Frequency` - System frequency
  - `CG_FSYSH_Frequency` - High-speed system clock
  - `CG_FSYSM_Frequency` - Middle-speed system clock
  - `CG_FT0H_Frequency` - High-speed system prescaler clock
  - `CG_FT0M_Frequency` - Middle-speed system prescaler clock

- **Added clock frequency function:**
  - `CG_GetClocksFrequency()` - Function to retrieve current clock frequencies

### 2. SPI Master Driver Improvements  
**File:** `targets/arm/mikroe/toshiba/src/spi_master/implementation_1/hal_ll_spi_master.c`

**Changes:**
- **Removed hardcoded system frequency:**
  - Removed `#define FSYS_FREQ 80000000UL` constant
  - Replaced with dynamic clock frequency retrieval

- **Simplified GPIO configuration macros:**
  - Removed complex SPI-specific GPIO configuration macros
  - Replaced with standard GPIO configuration modes:
    - `GPIO_CFG_SPI_SCK` → `GPIO_CFG_MODE_OUTPUT_PULLUP`
    - `GPIO_CFG_SPI_MISO` → `GPIO_CFG_DIGITAL_INPUT`
    - `GPIO_CFG_SPI_MOSI` → `GPIO_CFG_MODE_OUTPUT_PULLUP`

- **Enhanced bit rate calculation:**
  - **Dynamic frequency retrieval:** Uses `CG_GetClocksFrequency()` instead of hardcoded value
  - **Improved accuracy:** Calculates baud rate based on actual system frequency
  - **Better speed control:** More precise SPI speed configuration

### 3. SPI Configuration Details

**Updated Bit Rate Calculation:**
```c
// Old approach - hardcoded frequency
uint32_t fsys = FSYS_FREQ;
br_value = (fsys / (2 * desired_speed)) - 1;
map->hw_actual_speed = fsys / (2 * (br_value + 1));

// New approach - dynamic frequency
CG_ClocksTypeDef cg;
CG_GetClocksFrequency(&cg);
br_value = (cg.CG_FC_Frequency / (2 * desired_speed)) - 1;
map->hw_actual_speed = cg.CG_FC_Frequency / (2 * (br_value + 1));
```

**Simplified GPIO Configuration:**
```c
// Simplified pin configuration using standard GPIO modes
module.configs[0] = GPIO_CFG_MODE_OUTPUT_PULLUP;  // SCK
module.configs[1] = GPIO_CFG_DIGITAL_INPUT;       // MISO
module.configs[2] = GPIO_CFG_MODE_OUTPUT_PULLUP;  // MOSI
```

**Key Improvements:**
- **Dynamic clock management** - Adapts to actual system frequency
- **Simplified GPIO configuration** - Uses standard GPIO modes
- **Better SPI speed accuracy** - More precise baud rate calculation
- **Removed hardcoded dependencies** - More flexible and maintainable code
- **Enhanced driver robustness** - Adapts to different clock configurations