### PR TITLE
Toshiba 1-Wire first Implementation

### DIFF
--- a/targets/arm/mikroe/toshiba/include/one_wire/hal_ll_one_wire.h
+++ b/targets/arm/mikroe/toshiba/include/one_wire/hal_ll_one_wire.h
@@ -66,7 +66,8 @@ typedef struct {
  */
 typedef struct {
     hal_ll_pin_name_t data_pin; // One Wire data pin.
-    volatile uint32_t direction; // Register for altering GPIO pin direction.
+    volatile uint32_t direction_in; // Register for altering GPIO pin input direction.
+    volatile uint32_t direction_out; // Register for altering GPIO pin output direction.
     volatile uint32_t output_set; // Register for GPIO port bit set.
     volatile uint32_t output_clear; // Register for GPIO port bit reset.
     volatile uint32_t input; // Register for reading current GPIO pin state.


### PR DESCRIPTION
# 1-Wire Implementation for Toshiba TMPM4K MCU - lmrt-1Wire Branch

## 1-Wire Implementation (Commit: 5630680)
**Date:** September 9, 2025  
**Description:** 1-Wire first version

## Key Changes Analysis

### 1. GPIO Control Structure Enhancement
**File:** `targets/arm/mikroe/toshiba/include/one_wire/hal_ll_one_wire.h`

**Changes:**
- **Separated GPIO direction control** into dedicated input/output registers:
  - `direction_in` - Register for GPIO pin input direction control
  - `direction_out` - Register for GPIO pin output direction control
- **Replaced single direction register** with bidirectional control for better GPIO management

### 2. GPIO Register Access Implementation
**File:** `targets/arm/mikroe/toshiba/src/one_wire/hal_ll_one_wire.c`

**Changes:**
- **Corrected GPIO register mapping:**
  - Input enable: `&gpio_ptr->ie` (IE - Input Enable Register)
  - Output enable: `&gpio_ptr->cr` (CR - Control Register)
  - Data operations: `&gpio_ptr->data` for set/clear/read operations

- **Enhanced direction control logic:**
  ```c
  // Enable output, disable input
  *(uint32_t *)one_wire_handle.direction_out |= bit_location;
  *(uint32_t *)one_wire_handle.direction_in &= ~bit_location;
  
  // Disable output, enable input  
  *(uint32_t *)one_wire_handle.direction_out &= ~bit_location;
  *(uint32_t *)one_wire_handle.direction_in |= bit_location;
  ```