### PR TITLE
Toshiba GPIO config updates

### DIFF
--- a/targets/arm/mikroe/toshiba/include/gpio/hal_ll_gpio_constants.h
+++ b/targets/arm/mikroe/toshiba/include/gpio/hal_ll_gpio_constants.h
@@ -49,57 +49,19 @@ extern "C"{
 #endif
 
 // ===============================
-// GPIO configuration bits (PxDATA, PxCR, PxFR, PxOD, PxPUP, PxPDN, PxIE)
+// GPIO configuration bits (PxCR, PxFR, PxOD, PxPUP, PxPDN, PxIE)
 // ===============================
 
-// PxDATA - output value
-#define GPIO_CFG_PORT_OUTPUT_LOW          (0x0UL)
-#define GPIO_CFG_PORT_OUTPUT_HIGH         (0x1UL)
+// Individual GPIO control flags (bit flags for flexible configuration)
+#define GPIO_CFG_CR                         (0x01)   // Control Register (direction) flag
+#define GPIO_CFG_OD                         (0x02)   // Open Drain flag
+#define GPIO_CFG_PULL_UP                    (0x04)   // Pull-up flag
+#define GPIO_CFG_PULL_DOWN                  (0x08)   // Pull-down flag
+#define GPIO_CFG_IE                         (0x10)   // Input Enable flag
 
-// PxCR - direction
-#define GPIO_CFG_PORT_DIRECTION_INPUT     (0x0UL)   // PxCR = 0 -> Input
-#define GPIO_CFG_PORT_DIRECTION_OUTPUT    (0x1UL)   // PxCR = 1 -> Output
-
-// PxFR - function selection
-#define GPIO_CFG_GPIO_FUNCTION            (0x0UL)   // GPIO mode
-#define GPIO_CFG_ALT_FUNCTION             (0x1UL)   // Peripheral function
-
-// PxOD - output type
-#define GPIO_CFG_OTYPE_PP                 (0x0UL)   // Push-pull
-#define GPIO_CFG_OTYPE_OD                 (0x1UL)   // Open-drain
-
-// PxPUP - pull-up enable
-#define GPIO_CFG_PULL_UP                  (0x1UL)   // Pull-up enabled
-
-// PxPDN - pull-down enable
-#define GPIO_CFG_PULL_DOWN                (0x1UL)   // Pull-down enabled
-
-// No pull-up/down
-#define GPIO_CFG_PULL_NO                  (0x0UL)   // No pull-up/down
-
-// PxIE - input enable
-#define GPIO_CFG_INPUT_DISABLE              (0x0UL)
-#define GPIO_CFG_INPUT_ENABLE               (0x1UL)
-
-// Configuration bit field positions
-#define GPIO_CFG_OUTPUT_POS               (0)
-#define GPIO_CFG_ALT_FUNC_POS             (1)
-#define GPIO_CFG_OTYPE_POS                (2)
-#define GPIO_CFG_PULL_UP_POS              (3)
-#define GPIO_CFG_PULL_DOWN_POS            (4)
-#define GPIO_CFG_INPUT_POS                (5)
-
-// Combined configuration masks for common pin modes
-#define GPIO_CFG_ANALOG_INPUT             (GPIO_CFG_PORT_OUTPUT_LOW << GPIO_CFG_OUTPUT_POS | GPIO_CFG_PULL_NO << GPIO_CFG_PULL_UP_POS | GPIO_CFG_INPUT_DISABLE << GPIO_CFG_INPUT_POS)
-#define GPIO_CFG_DIGITAL_INPUT            (GPIO_CFG_INPUT_ENABLE << GPIO_CFG_INPUT_POS)
-#define GPIO_CFG_MODE_INPUT_PULLUP        (GPIO_CFG_INPUT_ENABLE << GPIO_CFG_INPUT_POS | (GPIO_CFG_PULL_UP << GPIO_CFG_PULL_UP_POS))
-#define GPIO_CFG_MODE_INPUT_PULLDOWN      (GPIO_CFG_INPUT_ENABLE << GPIO_CFG_INPUT_POS | (GPIO_CFG_PULL_DOWN << GPIO_CFG_PULL_DOWN_POS))
-#define GPIO_CFG_MODE_OUTPUT_PP           (GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | (GPIO_CFG_OTYPE_PP << GPIO_CFG_OTYPE_POS))
-#define GPIO_CFG_MODE_OUTPUT_OD           (GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | (GPIO_CFG_OTYPE_OD << GPIO_CFG_OTYPE_POS))
-#define GPIO_CFG_MODE_OUTPUT_PULLUP       (GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | (GPIO_CFG_PULL_UP << GPIO_CFG_PULL_UP_POS))
-#define GPIO_CFG_MODE_OUTPUT_PULLDOWN     (GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | (GPIO_CFG_PULL_DOWN << GPIO_CFG_PULL_DOWN_POS))
-#define GPIO_CFG_MODE_OUTPUT_OD_PULLUP    (GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | (GPIO_CFG_OTYPE_OD << GPIO_CFG_OTYPE_POS) | (GPIO_CFG_PULL_UP << GPIO_CFG_PULL_UP_POS))
-#define GPIO_CFG_MODE_OUTPUT_OD_PULLDOWN  (GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | (GPIO_CFG_OTYPE_OD << GPIO_CFG_OTYPE_POS) | (GPIO_CFG_PULL_DOWN << GPIO_CFG_PULL_DOWN_POS))
+#define GPIO_CFG_PORT_DIRECTION_OUTPUT      (GPIO_CFG_CR)
+#define GPIO_CFG_MODE_DIGITAL_INPUT         (GPIO_CFG_IE)
+#define GPIO_CFG_MODE_ANALOG_INPUT          (0x00)
 
 #ifdef __cplusplus
 }

--- a/targets/arm/mikroe/toshiba/src/adc/implementation_1/hal_ll_adc.c
+++ b/targets/arm/mikroe/toshiba/src/adc/implementation_1/hal_ll_adc.c
@@ -265,7 +265,7 @@ hal_ll_err_t hal_ll_adc_set_vref_input( handle_t *handle, hal_ll_adc_voltage_ref
     hal_ll_adc_handle_register_t *low_level_handle = hal_ll_adc_get_handle;
     hal_ll_adc_hw_specifics_map_local = hal_ll_get_specifics( hal_ll_adc_get_module_state_address );
 
-    if( low_level_handle->hal_ll_adc_handle == NULL ) {
+    if( NULL == low_level_handle->hal_ll_adc_handle ) {
         return HAL_LL_MODULE_ERROR;
     }
 

--- a/targets/arm/mikroe/toshiba/src/gpio/hal_ll_gpio.c
+++ b/targets/arm/mikroe/toshiba/src/gpio/hal_ll_gpio.c
@@ -50,7 +50,7 @@ void hal_ll_gpio_configure_pin(hal_ll_gpio_pin_t *pin, hal_ll_pin_name_t name, h
     pin->base = (hal_ll_gpio_base_t)hal_ll_gpio_port_base(hal_ll_gpio_port_index(name));
     pin->mask = hal_ll_gpio_pin_mask(name);
 
-    if ( direction == HAL_LL_GPIO_DIGITAL_INPUT)
+    if ( HAL_LL_GPIO_DIGITAL_INPUT == direction )
         hal_ll_gpio_digital_input(&pin->base, pin->mask);
     else
         hal_ll_gpio_digital_output(&pin->base, pin->mask);
@@ -128,7 +128,7 @@ void hal_ll_gpio_configure_port(hal_ll_gpio_port_t *port, hal_ll_port_name_t nam
     port->base = hal_ll_gpio_port_base(name);
     port->mask = mask;
 
-    if (direction == HAL_LL_GPIO_DIGITAL_INPUT)
+    if ( HAL_LL_GPIO_DIGITAL_INPUT == direction )
         hal_ll_gpio_digital_input(&port->base, port->mask);
     else
         hal_ll_gpio_digital_output(&port->base, port->mask);

--- a/targets/arm/mikroe/toshiba/src/spi_master/implementation_1/hal_ll_spi_master.c
+++ b/targets/arm/mikroe/toshiba/src/spi_master/implementation_1/hal_ll_spi_master.c
@@ -80,28 +80,14 @@ static volatile hal_ll_spi_master_handle_register_t hal_ll_module_state[ SPI_MOD
 #define HAL_LL_CG_SPI0_BIT 19
 #define HAL_LL_CG_SPI1_BIT 20
 
-#define BIT0 0x01
-#define BIT1 0x02
-#define BIT2 0x04
-#define BIT3 0x08
-#define BIT4 0x10
-#define BIT5 0x20
-#define BIT6 0x40
-#define BIT7 0x80
-
 #define HAL_LL_SPI_CR_ENABLE_BIT 0
 
 // SPI GPIO configuration macros
-#define GPIO_CFG_SPI_SCK                                                                                               \
-    ( GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | GPIO_CFG_ALT_FUNCTION << GPIO_CFG_ALT_FUNC_POS           \
-      | GPIO_CFG_PULL_UP << GPIO_CFG_PULL_UP_POS )
+#define GPIO_CFG_SPI_SCK  ( GPIO_CFG_PORT_DIRECTION_OUTPUT | GPIO_CFG_PULL_UP )
 
-#define GPIO_CFG_SPI_MISO                                                                                              \
-    ( GPIO_CFG_INPUT_ENABLE << GPIO_CFG_INPUT_POS | GPIO_CFG_ALT_FUNCTION << GPIO_CFG_ALT_FUNC_POS )
+#define GPIO_CFG_SPI_MISO ( GPIO_CFG_MODE_DIGITAL_INPUT )
 
-#define GPIO_CFG_SPI_MOSI                                                                                              \
-    ( GPIO_CFG_PORT_DIRECTION_OUTPUT << GPIO_CFG_OUTPUT_POS | GPIO_CFG_ALT_FUNCTION << GPIO_CFG_ALT_FUNC_POS           \
-      | GPIO_CFG_PULL_UP << GPIO_CFG_PULL_UP_POS )
+#define GPIO_CFG_SPI_MOSI ( GPIO_CFG_PORT_DIRECTION_OUTPUT | GPIO_CFG_PULL_UP )
 
 // CR0 register masks
 #define CR0_TSPIE_MASK   0x01


### PR DESCRIPTION
# GPIO Configuration System Refactoring for Toshiba TMPM4K MCU - lmrt-GPIO Branch

## GPIO Configuration Updates (Commit: 5ca541b)
**Date:** September 11, 2025  
**Description:** GPIO CONFIG updates

## Key Changes Analysis

### 1. GPIO Constants Architecture Refactoring
**File:** `targets/arm/mikroe/toshiba/include/gpio/hal_ll_gpio_constants.h`

**Changes:**
- **Replaced complex bit-field system** with simplified flag-based configuration
- **Introduced individual GPIO control flags:**
  - `GPIO_CFG_CR` (0x01) - Control Register (direction) flag
  - `GPIO_CFG_OD` (0x02) - Open Drain flag  
  - `GPIO_CFG_PULL_UP` (0x04) - Pull-up flag
  - `GPIO_CFG_PULL_DOWN` (0x08) - Pull-down flag
  - `GPIO_CFG_IE` (0x10) - Input Enable flag

- **Removed complex predefined configurations:**
  - Eliminated 57 lines of complex bit-field definitions
  - Removed position-based configuration system
  - Simplified from 9 predefined modes to 3 essential modes

- **New simplified mode definitions:**
  ```c
  #define GPIO_CFG_PORT_DIRECTION_OUTPUT  (GPIO_CFG_CR)
  #define GPIO_CFG_MODE_DIGITAL_INPUT     (GPIO_CFG_IE)
  #define GPIO_CFG_MODE_ANALOG_INPUT      (0x00)
  ```

### 2. GPIO Configuration Logic Modernization  
**File:** `targets/arm/mikroe/toshiba/src/gpio/implementation_1/hal_ll_gpio_port.c`

**Changes:**
- **Replaced switch-case with flag-based logic:**
  - Eliminated redundant switch cases
  - Implemented flexible bit-flag checking system

- **New configuration approach:**
  ```c
  // Control Register (CR) - Direction
  if ( config & GPIO_CFG_CR ) {
      gpio_ptr->cr |= pin_mask;    // Enable Output
  } else {
      gpio_ptr->cr &= ~pin_mask;   // Disable Output (Input mode)
  }
  
  // Input Enable (IE)
  if ( config & GPIO_CFG_IE ) {
      gpio_ptr->ie |= pin_mask;    // Enable Input
  } else {
      gpio_ptr->ie &= ~pin_mask;   // Disable Input
  }
  ```

### 4. Code Style and Safety Improvements
**Files:** Multiple implementation files

**Changes:**
- **Yoda conditions implementation:**
  ```c
  // Before: if( low_level_handle->hal_ll_adc_handle == NULL )
  // After:  if( NULL == low_level_handle->hal_ll_adc_handle )
  
  // Before: if (direction == HAL_LL_GPIO_DIGITAL_INPUT)
  // After:  if ( HAL_LL_GPIO_DIGITAL_INPUT == direction )
  ```

- **Enhanced code safety** with consistent comparison patterns

### 5. SPI Master Configuration Simplification
**File:** `targets/arm/mikroe/toshiba/src/spi_master/implementation_1/hal_ll_spi_master.c`

**Changes:**
- **Simplified SPI GPIO configuration macros:**
  ```c
  // Before: Complex multi-line bit-field operations
  // After: Simple flag combinations
  #define GPIO_CFG_SPI_SCK   ( GPIO_CFG_PORT_DIRECTION_OUTPUT | GPIO_CFG_PULL_UP )
  #define GPIO_CFG_SPI_MISO  ( GPIO_CFG_MODE_DIGITAL_INPUT )
  #define GPIO_CFG_SPI_MOSI  ( GPIO_CFG_PORT_DIRECTION_OUTPUT | GPIO_CFG_PULL_UP )
  ```