### PR TITLE
Updated to work for dual core and all other project types.

### DIFF
--- a/templates/necto/dev/project_templates/5_dual_core/core_0_dir_name/CMakeLists.txt
+++ b/templates/necto/dev/project_templates/5_dual_core/core_0_dir_name/CMakeLists.txt
@@ -4,10 +4,15 @@ set(CORE_SPECIFIC_SETUP_DIR ${CMAKE_SOURCE_DIR}/.meproject/setup/Debug/${CORE_0_
 list(APPEND CMAKE_PREFIX_PATH ${CORE_SPECIFIC_SETUP_DIR}/lib/cmake)
 list(APPEND CMAKE_MODULE_PATH ${CORE_SPECIFIC_SETUP_DIR}/lib/cmake)
 
-target_compile_options(${CORE_0_NAME} PRIVATE "${CORE_0_COMPILER_FLAGS}")
+set(CORE_NAME "${CORE_0_NAME_DEFINE}")
+include(coreUtils)
+set_flags(FLAGS)
+list(APPEND FLAGS "${CORE_0_COMPILER_FLAGS}")
+target_compile_options(${CORE_0_NAME} PRIVATE ${FLAGS})
+target_link_options(${CORE_0_NAME} PRIVATE ${FLAGS})
 target_compile_definitions(${CORE_0_NAME} PRIVATE ${CORE_0_MCU_HEADER_CORE_DEFINE})
-set(PRIMARY_CORE "${CORE_0_NAME}" CACHE STRING "Primary core selection" FORCE)
 
+set(PRIMARY_CORE "${CORE_0_NAME}" CACHE STRING "Primary core selection" FORCE)
 
 find_package(MikroC.Core REQUIRED)
 target_link_libraries(${CORE_0_NAME}

--- a/templates/necto/dev/project_templates/5_dual_core/core_1_dir_name/CMakeLists.txt
+++ b/templates/necto/dev/project_templates/5_dual_core/core_1_dir_name/CMakeLists.txt
@@ -4,10 +4,15 @@ set(CORE_SPECIFIC_SETUP_DIR ${CMAKE_SOURCE_DIR}/.meproject/setup/Debug/${CORE_1_
 list(APPEND CMAKE_PREFIX_PATH ${CORE_SPECIFIC_SETUP_DIR}/lib/cmake)
 list(APPEND CMAKE_MODULE_PATH ${CORE_SPECIFIC_SETUP_DIR}/lib/cmake)
 
-target_compile_options(${CORE_1_NAME} PRIVATE "${CORE_1_COMPILER_FLAGS}")
+set(CORE_NAME "${CORE_1_NAME_DEFINE}")
+include(coreUtils)
+set_flags(FLAGS)
+list(APPEND FLAGS "${CORE_1_COMPILER_FLAGS}")
+target_compile_options(${CORE_1_NAME} PRIVATE ${FLAGS})
+target_link_options(${CORE_1_NAME} PRIVATE ${FLAGS})
 target_compile_definitions(${CORE_1_NAME} PRIVATE ${CORE_1_MCU_HEADER_CORE_DEFINE})
-set(SECONDARY_CORE "${CORE_1_NAME}" CACHE STRING "Secondary core selection" FORCE)
 
+set(SECONDARY_CORE "${CORE_1_NAME}" CACHE STRING "Secondary core selection" FORCE)
 
 find_package(MikroC.Core REQUIRED)
 target_link_libraries(${CORE_1_NAME}

--- a/templates/necto/dev/toolchain_templates/ClangToolchain.cmake
+++ b/templates/necto/dev/toolchain_templates/ClangToolchain.cmake
@@ -25,15 +25,16 @@ list(APPEND CMAKE_PREFIX_PATH ${MIKROC_CORE_ROOT_PATH})
 
 list(APPEND CMAKE_MODULE_PATH %CMAKE_MODULE_PATH_VALUE%)
 
+if (DEFINED CORE_NAME AND NOT "${CORE_NAME}" STREQUAL "")
+    include(coreUtils)
+    set_flags(FLAGS)
+    message(INFO ": ${FLAGS}")
 
-include(coreUtils)
-set_flags(FLAGS)
-message(INFO ": ${FLAGS}")
-
-# add compiler option flags
-add_compile_options( ${FLAGS})
-# add link option flags
-add_link_options(${FLAGS})
+    # add compiler option flags
+    add_compile_options( ${FLAGS})
+    # add link option flags
+    add_link_options(${FLAGS})
+endif()
 
 %SDK_SETUP_BUILD_VALUE%
 

--- a/templates/necto/dev/toolchain_templates/GCCARMtoolchain.cmake
+++ b/templates/necto/dev/toolchain_templates/GCCARMtoolchain.cmake
@@ -25,15 +25,16 @@ list(APPEND CMAKE_PREFIX_PATH ${MIKROC_CORE_ROOT_PATH})
 
 list(APPEND CMAKE_MODULE_PATH %CMAKE_MODULE_PATH_VALUE%)
 
+if (DEFINED CORE_NAME AND NOT "${CORE_NAME}" STREQUAL "")
+    include(coreUtils)
+    set_flags(FLAGS)
+    message(INFO ": ${FLAGS}")
 
-include(coreUtils)
-set_flags(FLAGS)
-message(INFO ": ${FLAGS}")
-
-# add compiler option flags
-add_compile_options(${FLAGS})
-# add link option flags
-add_link_options(${FLAGS})
+    # add compiler option flags
+    add_compile_options(${FLAGS})
+    # add link option flags
+    add_link_options(${FLAGS})
+endif()
 
 %SDK_SETUP_BUILD_VALUE%
 


### PR DESCRIPTION
# ISSUE DESCRIPTION

> This PR is connected to private JIRA issue NS-3148.

## Changes

> Modified toolchain and project templates.

## Fixes

> Dual-core projects can now be configured correctly.
> Single projects can be configured as well.
> With upcoming NECTO release, the database workaround can be removed.

---