### PR TITLE
Added auto generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ build*
 .clangd
 compile_commands.json
 settings.json
+flatten_me.h
+eth_driver.h
+tusb_config.h
+usb_isr_routines.h
+usb_isr_routines.c
+lcd_controllers.h


### PR DESCRIPTION
Added:

flatten_me.h
eth_driver.h
tusb_config.h
usb_isr_routines.h
usb_isr_routines.c
lcd_controllers.h

There might be more of these files. Check if all of those really need to be generated in the first place.
