### PR TITLE
NXP FreeRTOS port

### DIFF
--- a/cmake/rtosUtils.cmake
+++ b/cmake/rtosUtils.cmake
@@ -15,7 +15,7 @@ function(check_rtos_components has_rtos)
     endif()
 
     # Non-AI SDK: enable for supported vendor families
-    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32.+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$")
+    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32.+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$" OR "${MCU_NAME}" MATCHES "^MK.+$")
         set(${has_rtos} "true" PARENT_SCOPE)
     else()
         message(WARNING ": Selected mcu (${MCU_NAME}) doesn't have RTOS support enabled.")
@@ -53,7 +53,7 @@ function(get_rtos_compile_definitions out_defs)
     set(defs "")
 
     # STM32: core types for SysTick helper (SCB/SysTick types not always present via core files)
-    if("${MCU_NAME}" MATCHES "^STM32.+$")
+    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^MK.+$")
         list(APPEND defs MSDK_SYSTICK_DEFINE_CORE_TYPES)
     endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,6 @@ endif()
 
 add_subdirectory(sprint)
 
-if( "${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32(MX|MZ).+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$")
+if( "${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32(MX|MZ).+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$" OR "${MCU_NAME}" MATCHES "^MK.+$")
     add_subdirectory(freertos)
 endif()


### PR DESCRIPTION
## Summary

Enable FreeRTOS support for NXP **MK** targets by extending CMake gating and tests selection.

## What changed

* Updated RTOS gating logic to recognize **NXP MK** MCUs (`MCU_NAME` matches `^MK.+$`) so FreeRTOS components are enabled for these targets.
* Updated RTOS requirements check to include **MK** family in the supported set.
* Updated FreeRTOS test CMake logic so the correct util/test setup is selected for **MK** targets.

## Targets covered

* **MKV58F1M0VLQ24** (Cortex-M7)
* **MK64FN1M0VDC12** (Cortex-M4)

## Notes

* No port sources were changed: existing **CM4/CM7** FreeRTOS ports are reused.
