### PR TITLE
FreeRTOS port for TIVA

### DIFF
--- a/cmake/rtosUtils.cmake
+++ b/cmake/rtosUtils.cmake
@@ -15,7 +15,7 @@ function(check_rtos_components has_rtos)
     endif()
 
     # Non-AI SDK: enable for supported vendor families
-    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32.+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$" OR "${MCU_NAME}" MATCHES "^MK.+$")
+    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32.+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$" OR "${MCU_NAME}" MATCHES "^MK.+$" OR "${MCU_NAME}" MATCHES "^TM4C.+$")
         set(${has_rtos} "true" PARENT_SCOPE)
     else()
         message(WARNING ": Selected mcu (${MCU_NAME}) doesn't have RTOS support enabled.")
@@ -53,7 +53,7 @@ function(get_rtos_compile_definitions out_defs)
     set(defs "")
 
     # STM32: core types for SysTick helper (SCB/SysTick types not always present via core files)
-    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^MK.+$")
+    if("${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^MK.+$" OR "${MCU_NAME}" MATCHES "^TM4C.+$")
         list(APPEND defs MSDK_SYSTICK_DEFINE_CORE_TYPES)
     endif()
 
@@ -215,6 +215,7 @@ macro(rtos_freertos_generate_config fileDestination fileName)
     # - STM32 : CM0(G0,L0,F0)  => 2
     # - Renesas: CM23(R7FA2E3) => 2
     #            CM33(R7FA4M3) => 3
+    # - Tiva :   CM4F(TM4C)    => 3
     # ---------------------------------------------------------------------
     # Default: Cortex-M3/M4/M7/M85
     set(prio_bits 4)
@@ -224,7 +225,7 @@ macro(rtos_freertos_generate_config fileDestination fileName)
         set(prio_bits 2)
 
     # Supported Cortex-M33 targets (Renesas RA4M3/RA6M3)
-    elseif(CORE_NAME MATCHES "M33")
+    elseif(CORE_NAME MATCHES "M33" OR "${MCU_NAME}" MATCHES "^TM4C.+$")
         set(prio_bits 3)
     endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,6 @@ endif()
 
 add_subdirectory(sprint)
 
-if( "${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32(MX|MZ).+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$" OR "${MCU_NAME}" MATCHES "^MK.+$")
+if( "${MCU_NAME}" MATCHES "^STM32.+$" OR "${MCU_NAME}" MATCHES "^R7F.+$"  OR "${MCU_NAME}" MATCHES "^PIC32(MX|MZ).+$" OR "${MCU_NAME}" MATCHES "^TMPM4K.+$" OR "${MCU_NAME}" MATCHES "^MK.+$" OR "${MCU_NAME}" MATCHES "^TM4C.+$")
     add_subdirectory(freertos)
 endif()

--- a/tests/freertos/adc/systick.h
+++ b/tests/freertos/adc/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/binary_semaphore/systick.h
+++ b/tests/freertos/binary_semaphore/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/counting_semaphore/systick.h
+++ b/tests/freertos/counting_semaphore/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/event_group/systick.h
+++ b/tests/freertos/event_group/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/i2c/systick.h
+++ b/tests/freertos/i2c/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/mutex/systick.h
+++ b/tests/freertos/mutex/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/pwm/systick.h
+++ b/tests/freertos/pwm/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/queue/systick.h
+++ b/tests/freertos/queue/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/spi/systick.h
+++ b/tests/freertos/spi/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/sw_timer/systick.h
+++ b/tests/freertos/sw_timer/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/task_notification/systick.h
+++ b/tests/freertos/task_notification/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/task_test/systick.h
+++ b/tests/freertos/task_test/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/uart/systick.h
+++ b/tests/freertos/uart/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 

--- a/tests/freertos/usb/systick.h
+++ b/tests/freertos/usb/systick.h
@@ -1,4 +1,5 @@
 #include <mcu.h>
+#include <stdint.h>
 
 #define TIMER_SYSTICK_HANDLER() __attribute__ ((interrupt("IRQ"))) void SysTick_Handler(void)
 


### PR DESCRIPTION

**Summary**

This PR integrates Tiva TM4C123GH6PZ and TM4C129XNCZAD into the SDK FreeRTOS flow.

**What changed**

* Enabled FreeRTOS for TM4C targets by extending RTOS enablement logic (MCU_NAME regex for `TM4C...`) so these MCUs are included in RTOS-supported families.
* Adjusted dynamically generated `FreeRTOSConfig.h` for Tiva:

  * Set `configPRIO_BITS` to **3** for TM4C targets (Tiva uses 3 implemented NVIC priority bits even on Cortex-M4).
* Updated `systick.h` to be compatible with Tiva core headers:

  * Added `#include <stdint.h>` because Tiva core headers do not guarantee integer typedefs in this include chain.
  * Added SCB definition support in `systick.h` (same approach as STM32/NXP; opposite of Renesas/Toshiba where SCB is already defined in core headers).
* Updated FreeRTOS test CMakeLists where needed for TM4C targets to build and run with the existing Cortex-M4 FreeRTOS port.

**Result**

* No port sources were changed: existing CM4 FreeRTOS port is reused.

