### PR TITLE
Minor fix in SAU SPI

### DIFF
--- a/changelog/v2.18.1/changelog.md
+++ b/changelog/v2.18.1/changelog.md
@@ -17,6 +17,7 @@
 - [`v2.18.1`](#v2181)
   - [Changes](#changes)
     - [RENESAS](#renesas)
+    - [Fixes](#fixes)
     - [NEW HARDWARE](#new-hardware)
 
 ### <font color=red>RENESAS</font>
@@ -70,6 +71,10 @@
 + GPIO (Full module support)
 + 1-Wire (Full module support)
 
+### Fixes
+
++ Fixed a bug which caused incorrect pin mapping for certain RA0 MCU variants.
+  + All SPI modules and channels on RA0 MCUs are now fully supported and correctly mapped.
 
 ### NEW HARDWARE
 

--- a/targets/arm/mikroe/renesas/src/spi_master/implementation_3/hal_ll_spi_master.c
+++ b/targets/arm/mikroe/renesas/src/spi_master/implementation_3/hal_ll_spi_master.c
@@ -105,6 +105,7 @@ typedef struct {
     uint16_t soe;
     uint16_t _unused1[4];
     uint16_t sol;
+    uint16_t _unused2;
     uint16_t ssc;
 } hal_ll_spi_master_base_handle_t;
 
@@ -873,6 +874,9 @@ static void hal_ll_spi_master_init( hal_ll_spi_master_hw_specifics_map_t *map ) 
     hal_ll_spi_master_base_handle_t *hal_ll_hw_reg = ( hal_ll_spi_master_base_handle_t * )map->base;
 
     hal_ll_spi_master_module_enable( map, true );
+
+    // Stop channel operation before configuration.
+    set_reg_bit( &hal_ll_hw_reg->st, map->channel );
 
     hal_ll_spi_master_hw_init( map );
 

--- a/targets/arm/mikroe/renesas/src/spi_master/implementation_3/hal_ll_spi_master.c
+++ b/targets/arm/mikroe/renesas/src/spi_master/implementation_3/hal_ll_spi_master.c
@@ -694,12 +694,8 @@ static void hal_ll_spi_master_map_pins( uint8_t module_index, hal_ll_spi_pin_id 
                                     hal_ll_spi_master_mosi_map[ index_list[ module_index ].pin_mosi ].af;
 
     // Map channel numbers for easier access in low level functions.
-    hal_ll_spi_master_hw_specifics_map[ module_index ].channel  =
-                                    hal_ll_spi_master_sck_map[ module_index ].channel;
     hal_ll_spi_master_hw_specifics_map[ module_index ].channel =
-                                    hal_ll_spi_master_miso_map[ module_index ].channel;
-    hal_ll_spi_master_hw_specifics_map[ module_index ].channel =
-                                    hal_ll_spi_master_mosi_map[ module_index ].channel;
+                                    hal_ll_spi_master_sck_map[ index_list[ module_index ].pin_sck ].channel;
 }
 
 static void hal_ll_spi_master_alternate_functions_set_state( hal_ll_spi_master_hw_specifics_map_t *map,


### PR DESCRIPTION
This addition prevents the first transmitted byte from being lost.