### PR TITLE
Add W5500 support to SPI Ethernet library

### DIFF
--- a/middleware/spi_ethernet/lib/CMakeLists.txt
+++ b/middleware/spi_ethernet/lib/CMakeLists.txt
@@ -2,9 +2,11 @@
 mikrosdk_add_library(lib_spi_ethernet MikroSDK.SpiEthernet
     src/spi_ethernet.c
     src/spi_ethernet_enc28j60.c
+    src/spi_ethernet_w5500.c
 
     include/spi_ethernet.h
     include/spi_ethernet_enc28j60.h
+    include/spi_ethernet_w5500.h
 )
 
 target_link_libraries(lib_spi_ethernet PUBLIC

--- a/middleware/spi_ethernet/lib/include/spi_ethernet.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet.h
@@ -55,6 +55,8 @@ extern "C"{
 #define ETH_HEADER_SIZE 14
 #define ETH_MAX_PAYLOAD 1500
 #define ETH_MAX_FRAME   ( ETH_HEADER_SIZE + ETH_MAX_PAYLOAD )
+#define ENC28J60        0
+#define W5500           1
 
 typedef struct
 {
@@ -400,6 +402,18 @@ typedef struct {
     #define spi_eth_get_rev                             enc28j60_get_rev
     #define spi_eth_phy_read                             enc28j60_phy_read
     typedef enc28j60_cfg_t                              spi_eth_cfg_t;
+#endif
+
+#if SPI_ETH_CHIP == W5500
+    #include "spi_ethernet_w5500.h"
+    extern spi_ethernet_driver_t                        w5500_driver;
+    extern pin_name_t                                   w5500_cs_pin;
+    #define SPI_ETH_DRIVER                              w5500_driver
+    #define SPI_ETH_MAP_MIKROBUS( eth, mikrobus )       W5500_MAP_MIKROBUS( eth, mikrobus )
+    #define spi_eth_cfg_setup                           w5500_cfg_setup
+    #define spi_eth_configure                           w5500_configure
+    #define spi_eth_get_rev                             w5500_get_rev
+    typedef w5500_cfg_t                                 spi_eth_cfg_t;
 #endif
 
 #ifdef __cplusplus

--- a/middleware/spi_ethernet/lib/include/spi_ethernet_w5500.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet_w5500.h
@@ -1,0 +1,163 @@
+/****************************************************************************
+**
+** Copyright ( C ) ${COPYRIGHT_YEAR} MikroElektronika d.o.o.
+** Contact: https://www.mikroe.com/contact
+**
+** This file is part of the mikroSDK package
+**
+** Commercial License Usage
+**
+** Licensees holding valid commercial NECTO compilers AI licenses may use this
+** file in accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The MikroElektronika Company.
+** For licensing terms and conditions see
+** https://www.mikroe.com/legal/software-license-agreement.
+** For further information use the contact form at
+** https://www.mikroe.com/contact.
+**
+**
+** GNU Lesser General Public License Usage
+**
+** Alternatively, this file may be used for
+** non-commercial projects under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+** OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+** DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+** OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+** OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+****************************************************************************/
+
+/*!
+ * @file spi_ethernet_w5500.h
+ * @brief SPI Ethernet WIZnet W5500 Driver.
+ */
+
+#ifndef SPI_ETHERNET_W5500_H
+#define SPI_ETHERNET_W5500_H
+
+#include "drv_digital_out.h"
+#include "drv_spi_master.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#define W5500_MAP_MIKROBUS( cfg, mikrobus ) \
+    cfg.miso  = MIKROBUS( mikrobus, MIKROBUS_MISO ); \
+    cfg.mosi  = MIKROBUS( mikrobus, MIKROBUS_MOSI ); \
+    cfg.sck   = MIKROBUS( mikrobus, MIKROBUS_SCK );  \
+    cfg.cs    = MIKROBUS( mikrobus, MIKROBUS_CS );   \
+    cfg.rst   = MIKROBUS( mikrobus, MIKROBUS_RST );
+
+typedef struct {
+    pin_name_t miso;
+    pin_name_t mosi;
+    pin_name_t sck;
+    pin_name_t cs;
+    pin_name_t rst;
+
+    uint32_t spi_speed;
+    spi_master_mode_t spi_mode;
+
+    uint8_t mac[ 6 ];
+    uint8_t ip[ 4 ];
+    uint8_t full_duplex;
+} w5500_cfg_t;
+
+// Forward declarations of driver functions
+void     w5500_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv );
+void     w5500_cfg_setup( w5500_cfg_t *cfg );
+uint8_t  w5500_configure( spi_ethernet_t *eth, spi_master_t *spi, w5500_cfg_t *cfg );
+uint16_t w5500_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint16_t w5500_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint8_t  w5500_packet_available( spi_ethernet_t *eth );
+uint8_t  w5500_get_link_status( void );
+uint8_t  w5500_get_rev( void );
+int      w5500_set_mac( uint8_t mac[ 6 ] );
+int      w5500_get_mac( uint8_t mac[ 6 ] );
+int      w5500_set_ip( uint8_t ip[ 4 ] );
+int      w5500_get_ip( uint8_t ip[ 4 ] );
+
+extern spi_ethernet_driver_t w5500_driver;
+extern pin_name_t            w5500_cs_pin;
+
+// Control byte: OM (operation mode) bits [1:0]
+#define W5500_OM_VDM        0x00
+#define W5500_OM_FDM1       0x01
+#define W5500_OM_FDM2       0x02
+#define W5500_OM_FDM4       0x03
+// Control byte: R/W bit [2]
+#define W5500_RWB_READ      0x00
+#define W5500_RWB_WRITE     0x04
+// Control byte: Block Select Bits [7:3]
+#define W5500_BSB_COMMON_REG        ( 0x00 << 3 )
+#define W5500_BSB_SOCKET0_REG( n )  ( ( ( 1 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+#define W5500_BSB_SOCKET0_TX( n )   ( ( ( 2 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+#define W5500_BSB_SOCKET0_RX( n )   ( ( ( 3 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+// Common register block (BSB = 0x00)
+#define W5500_MR             0x0000
+#define W5500_GAR            0x0001
+#define W5500_SUBR           0x0005
+#define W5500_SHAR           0x0009
+#define W5500_SIPR           0x000F
+#define W5500_INTLEVEL       0x0013
+#define W5500_IR             0x0015
+#define W5500_IMR            0x0016
+#define W5500_SIR            0x0017
+#define W5500_SIMR           0x0018
+#define W5500_RTR            0x0019
+#define W5500_RCR            0x001B
+#define W5500_PHYCFGR        0x002E
+#define W5500_VERSIONR       0x0039
+/* Socket n register block */
+#define W5500_Sn_MR           0x0000
+#define W5500_Sn_CR           0x0001
+#define W5500_Sn_IR           0x0002
+#define W5500_Sn_SR           0x0003
+#define W5500_Sn_PORT         0x0004
+#define W5500_Sn_DHAR         0x0006
+#define W5500_Sn_DIPR         0x000C
+#define W5500_Sn_DPORT        0x0010
+#define W5500_Sn_MSSR         0x0012
+#define W5500_Sn_TOS          0x0015
+#define W5500_Sn_TTL          0x0016
+#define W5500_Sn_RXBUF_SIZE   0x001E
+#define W5500_Sn_TXBUF_SIZE   0x001F
+#define W5500_Sn_TX_FSR       0x0020
+#define W5500_Sn_TX_RD        0x0022
+#define W5500_Sn_TX_WR        0x0024
+#define W5500_Sn_RX_RSR       0x0026
+#define W5500_Sn_RX_RD        0x0028
+#define W5500_Sn_RX_WR        0x002A
+/* Sn_MR protocol bits [3:0] */
+#define W5500_Sn_MR_CLOSED    0x00
+#define W5500_Sn_MR_TCP       0x01
+#define W5500_Sn_MR_UDP       0x02
+#define W5500_Sn_MR_MACRAW    0x04
+#define W5500_Sn_MR_MF        0x40
+/* Sn_CR commands */
+#define W5500_Sn_CR_OPEN      0x01
+#define W5500_Sn_CR_CLOSE     0x10
+#define W5500_Sn_CR_SEND      0x20
+#define W5500_Sn_CR_RECV      0x40
+/* Sn_SR values of interest */
+#define W5500_SOCK_CLOSED     0x00
+#define W5500_SOCK_MACRAW     0x42
+
+/* PHYCFGR bits */
+#define W5500_PHYCFGR_LNK_MASK  0x01
+#define W5500_PHYCFGR_RST       0x80
+
+#define W5500_FRAME_SIZE 1518
+
+#endif
+
+// ------------------------------------------------------------------------ END

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
@@ -40,10 +40,6 @@
 /*!
  * @file spi_ethernet_w5500.c
  * @brief SPI Ethernet WIZnet W5500 Driver.
- *
- * @note Socket 0 est ouvert en mode MACRAW pour exposer la meme API
- * trame-Ethernet-brute que le driver ENC28J60, afin que le parsing
- * ARP/ICMP/TCP de main.c reste independant de la puce.
  */
 
 #include "spi_ethernet.h"

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
@@ -90,10 +90,7 @@ spi_ethernet_driver_t w5500_driver = {
     .get_ip          = w5500_get_ip
 };
 
-/* --------------------------------------------------------------------
- * Acces SPI bas niveau
- * Chaque transaction : [ addr high ][ addr low ][ control byte ][ data... ]
- * -------------------------------------------------------------------- */
+// Low-Level SPI Access
 static uint8_t w5500_read_reg( uint16_t addr, uint8_t bsb ) {
     uint8_t header[ 3 ];
     uint8_t val;
@@ -264,7 +261,7 @@ uint8_t w5500_get_rev( void ) {
     return w5500_hwRev;
 }
 
-// Addressage
+// Addressing
 int w5500_set_mac( uint8_t mac[ 6 ] ) {
     memcpy( w5500_mac_addr, mac, 6 );
     w5500_write_burst( W5500_SHAR, W5500_BSB_COMMON_REG, mac, 6 );

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
@@ -1,0 +1,330 @@
+/****************************************************************************
+**
+** Copyright ( C ) ${COPYRIGHT_YEAR} MikroElektronika d.o.o.
+** Contact: https://www.mikroe.com/contact
+**
+** This file is part of the mikroSDK package
+**
+** Commercial License Usage
+**
+** Licensees holding valid commercial NECTO compilers AI licenses may use this
+** file in accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The MikroElektronika Company.
+** For licensing terms and conditions see
+** https://www.mikroe.com/legal/software-license-agreement.
+** For further information use the contact form at
+** https://www.mikroe.com/contact.
+**
+**
+** GNU Lesser General Public License Usage
+**
+** Alternatively, this file may be used for
+** non-commercial projects under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+** OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+** DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+** OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+** OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+****************************************************************************/
+
+/*!
+ * @file spi_ethernet_w5500.c
+ * @brief SPI Ethernet WIZnet W5500 Driver.
+ *
+ * @note Socket 0 est ouvert en mode MACRAW pour exposer la meme API
+ * trame-Ethernet-brute que le driver ENC28J60, afin que le parsing
+ * ARP/ICMP/TCP de main.c reste independant de la puce.
+ */
+
+#include "spi_ethernet.h"
+#include "spi_ethernet_w5500.h"
+#include "drv_spi_master.h"
+#include <delays.h>
+#include <string.h>
+
+#define SPI_ETH_OK           0x00
+#define SPI_ETH_INIT_ERROR   0xFF
+
+#define W5500_IR_SENDOK      0x10
+
+pin_name_t w5500_cs_pin;
+
+static spi_ethernet_t *current_eth = NULL;
+static uint8_t w5500_mac_addr[ 6 ];
+static uint8_t w5500_ipaddr[ 4 ];
+static uint8_t w5500_hwRev;
+
+static uint8_t   w5500_read_reg( uint16_t addr, uint8_t bsb );
+static void      w5500_write_reg( uint16_t addr, uint8_t bsb, uint8_t val_in );
+static uint16_t  w5500_read_reg16( uint16_t addr, uint8_t bsb );
+static void      w5500_write_reg16( uint16_t addr, uint8_t bsb, uint16_t value );
+static void      w5500_read_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len );
+static void      w5500_write_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len );
+static void      w5500_hw_reset( spi_ethernet_t *eth );
+static void      w5500_wait_socket_cmd( void );
+static void      w5500_open_socket0_macraw( void );
+
+uint16_t w5500_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint16_t w5500_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint8_t  w5500_packet_available( spi_ethernet_t *eth );
+
+spi_ethernet_driver_t w5500_driver = {
+    .init            = w5500_init,
+    .send_packet     = w5500_send_packet,
+    .read_packet     = w5500_read_packet,
+    .available       = w5500_packet_available,
+    .get_link_status = w5500_get_link_status,
+    .set_mac         = w5500_set_mac,
+    .get_mac         = w5500_get_mac,
+    .set_ip          = w5500_set_ip,
+    .get_ip          = w5500_get_ip
+};
+
+/* --------------------------------------------------------------------
+ * Acces SPI bas niveau
+ * Chaque transaction : [ addr high ][ addr low ][ control byte ][ data... ]
+ * -------------------------------------------------------------------- */
+static uint8_t w5500_read_reg( uint16_t addr, uint8_t bsb ) {
+    uint8_t header[ 3 ];
+    uint8_t val;
+
+    header[ 0 ] = ( uint8_t )( addr >> 8 );
+    header[ 1 ] = ( uint8_t )( addr & 0xFF );
+    header[ 2 ] = ( uint8_t )( bsb | W5500_RWB_READ | W5500_OM_FDM1 );
+    val = 0;
+
+    spi_master_select_device( w5500_cs_pin );
+    spi_master_write_then_read( current_eth->spi, header, 3, &val, 1 );
+    spi_master_deselect_device( w5500_cs_pin );
+
+    return val;
+}
+
+static void w5500_write_reg( uint16_t addr, uint8_t bsb, uint8_t val_in ) {
+    uint8_t frame[ 4 ];
+
+    frame[ 0 ] = ( uint8_t )( addr >> 8 );
+    frame[ 1 ] = ( uint8_t )( addr & 0xFF );
+    frame[ 2 ] = ( uint8_t )( bsb | W5500_RWB_WRITE | W5500_OM_FDM1 );
+    frame[ 3 ] = val_in;
+
+    spi_master_select_device( w5500_cs_pin );
+    spi_master_write( current_eth->spi, frame, 4 );
+    spi_master_deselect_device( w5500_cs_pin );
+}
+
+static uint16_t w5500_read_reg16( uint16_t addr, uint8_t bsb ) {
+    uint8_t buf[ 2 ];
+    w5500_read_burst( addr, bsb, buf, 2 );
+    return ( uint16_t )( ( ( uint16_t )buf[ 0 ] << 8 ) | buf[ 1 ] );
+}
+
+static void w5500_write_reg16( uint16_t addr, uint8_t bsb, uint16_t value ) {
+    uint8_t buf[ 2 ];
+    buf[ 0 ] = ( uint8_t )( value >> 8 );
+    buf[ 1 ] = ( uint8_t )( value & 0xFF );
+    w5500_write_burst( addr, bsb, buf, 2 );
+}
+
+static void w5500_read_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len ) {
+    uint8_t header[ 3 ];
+
+    header[ 0 ] = ( uint8_t )( addr >> 8 );
+    header[ 1 ] = ( uint8_t )( addr & 0xFF );
+    header[ 2 ] = ( uint8_t )( bsb | W5500_RWB_READ | W5500_OM_VDM );
+
+    spi_master_select_device( w5500_cs_pin );
+    spi_master_write_then_read( current_eth->spi, header, 3, buf, len );
+    spi_master_deselect_device( w5500_cs_pin );
+}
+
+static void w5500_write_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len ) {
+    uint8_t header[ 3 ];
+
+    header[ 0 ] = ( uint8_t )( addr >> 8 );
+    header[ 1 ] = ( uint8_t )( addr & 0xFF );
+    header[ 2 ] = ( uint8_t )( bsb | W5500_RWB_WRITE | W5500_OM_VDM );
+
+    spi_master_select_device( w5500_cs_pin );
+    spi_master_write( current_eth->spi, header, 3 );
+    spi_master_write( current_eth->spi, buf, len );
+    spi_master_deselect_device( w5500_cs_pin );
+}
+
+// Init
+static void w5500_hw_reset( spi_ethernet_t *eth ) {
+    digital_out_high( &eth->reset ); Delay_ms( 10 );
+    digital_out_low( &eth->reset );  Delay_ms( 1 );
+    digital_out_high( &eth->reset ); Delay_ms( 100 );
+}
+
+static void w5500_wait_socket_cmd( void ) {
+    uint16_t tries = 0;
+    while ( w5500_read_reg( W5500_Sn_CR, W5500_BSB_SOCKET0_REG( 0 ) ) ) {
+        Delay_ms( 1 );
+        if ( ++tries > 200 ) break;
+    }
+}
+
+static void w5500_open_socket0_macraw( void ) {
+    w5500_write_reg( W5500_Sn_MR, W5500_BSB_SOCKET0_REG( 0 ), W5500_Sn_MR_MACRAW | W5500_Sn_MR_MF );
+    w5500_write_reg( W5500_Sn_CR, W5500_BSB_SOCKET0_REG( 0 ), W5500_Sn_CR_OPEN );
+    w5500_wait_socket_cmd( );
+}
+
+void w5500_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv ) {
+    current_eth = eth;
+
+    w5500_hw_reset( eth );
+
+    memcpy( w5500_mac_addr, eth->mac, 6 );
+    memcpy( w5500_ipaddr, &eth->ip, 4 );
+
+    w5500_hwRev = w5500_read_reg( W5500_VERSIONR, W5500_BSB_COMMON_REG );
+
+    w5500_set_mac( w5500_mac_addr );
+    w5500_set_ip( w5500_ipaddr );
+
+    w5500_open_socket0_macraw( );
+}
+
+// Data Tranfert (MACRAW, socket 0)
+uint16_t w5500_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len ) {
+    uint16_t wr_ptr;
+    current_eth = eth;
+
+    wr_ptr = w5500_read_reg16( W5500_Sn_TX_WR, W5500_BSB_SOCKET0_REG( 0 ) );
+    w5500_write_burst( wr_ptr, W5500_BSB_SOCKET0_TX( 0 ), buf, len );
+    w5500_write_reg16( W5500_Sn_TX_WR, W5500_BSB_SOCKET0_REG( 0 ), ( uint16_t )( wr_ptr + len ) );
+
+    w5500_write_reg( W5500_Sn_CR, W5500_BSB_SOCKET0_REG( 0 ), W5500_Sn_CR_SEND );
+    w5500_wait_socket_cmd( );
+
+    w5500_write_reg( W5500_Sn_IR, W5500_BSB_SOCKET0_REG( 0 ), W5500_IR_SENDOK );
+
+    return len;
+}
+
+uint8_t w5500_packet_available( spi_ethernet_t *eth ) {
+    uint16_t rsr;
+    if ( !eth ) return 0;
+
+    rsr = w5500_read_reg16( W5500_Sn_RX_RSR, W5500_BSB_SOCKET0_REG( 0 ) );
+    return ( rsr > 0 ) ? 1 : 0;
+}
+
+uint16_t w5500_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t max_len ) {
+    uint16_t rd_ptr, frame_len, data_len, copy_len;
+    uint8_t hdr[ 2 ];
+    current_eth = eth;
+
+    if ( !w5500_packet_available( eth ) ) return 0;
+
+    rd_ptr = w5500_read_reg16( W5500_Sn_RX_RD, W5500_BSB_SOCKET0_REG( 0 ) );
+
+    w5500_read_burst( rd_ptr, W5500_BSB_SOCKET0_RX( 0 ), hdr, 2 );
+    frame_len = ( uint16_t )( ( ( uint16_t )hdr[ 0 ] << 8 ) | hdr[ 1 ] );
+
+    if ( frame_len < 2 ) {
+        w5500_write_reg16( W5500_Sn_RX_RD, W5500_BSB_SOCKET0_REG( 0 ), ( uint16_t )( rd_ptr + 2 ) );
+        w5500_write_reg( W5500_Sn_CR, W5500_BSB_SOCKET0_REG( 0 ), W5500_Sn_CR_RECV );
+        return 0;
+    }
+
+    data_len = ( uint16_t )( frame_len - 2 );
+    copy_len = ( data_len > max_len ) ? max_len : data_len;
+    w5500_read_burst( ( uint16_t )( rd_ptr + 2 ), W5500_BSB_SOCKET0_RX( 0 ), buf, copy_len );
+
+    w5500_write_reg16( W5500_Sn_RX_RD, W5500_BSB_SOCKET0_REG( 0 ), ( uint16_t )( rd_ptr + frame_len ) );
+    w5500_write_reg( W5500_Sn_CR, W5500_BSB_SOCKET0_REG( 0 ), W5500_Sn_CR_RECV );
+
+    return copy_len;
+}
+
+// Link / Identification
+uint8_t w5500_get_link_status( void ) {
+    uint8_t phycfgr;
+    if ( !current_eth ) return 0;
+
+    phycfgr = w5500_read_reg( W5500_PHYCFGR, W5500_BSB_COMMON_REG );
+    return ( phycfgr & W5500_PHYCFGR_LNK_MASK ) ? 1 : 0;
+}
+
+uint8_t w5500_get_rev( void ) {
+    return w5500_hwRev;
+}
+
+// Addressage
+int w5500_set_mac( uint8_t mac[ 6 ] ) {
+    memcpy( w5500_mac_addr, mac, 6 );
+    w5500_write_burst( W5500_SHAR, W5500_BSB_COMMON_REG, mac, 6 );
+    return 1;
+}
+
+int w5500_get_mac( uint8_t mac[ 6 ] ) {
+    memcpy( mac, w5500_mac_addr, 6 );
+    return 1;
+}
+
+int w5500_set_ip( uint8_t ip[ 4 ] ) {
+    memcpy( w5500_ipaddr, ip, 4 );
+    w5500_write_burst( W5500_SIPR, W5500_BSB_COMMON_REG, ip, 4 );
+    return 1;
+}
+
+int w5500_get_ip( uint8_t ip[ 4 ] ) {
+    memcpy( ip, w5500_ipaddr, 4 );
+    return 1;
+}
+
+// Config / Setup
+void w5500_cfg_setup( w5500_cfg_t *cfg ) {
+    cfg->miso = HAL_PIN_NC;
+    cfg->mosi = HAL_PIN_NC;
+    cfg->sck  = HAL_PIN_NC;
+    cfg->cs   = HAL_PIN_NC;
+    cfg->rst  = HAL_PIN_NC;
+
+    cfg->spi_speed = 1000000;
+    cfg->spi_mode  = SPI_MASTER_MODE_0;
+
+    cfg->full_duplex = 0;
+}
+
+uint8_t w5500_configure( spi_ethernet_t *eth, spi_master_t *spi, w5500_cfg_t *cfg ) {
+    spi_master_config_t spi_cfg;
+    spi_master_configure_default( &spi_cfg );
+
+    spi_cfg.sck   = cfg->sck;
+    spi_cfg.miso  = cfg->miso;
+    spi_cfg.mosi  = cfg->mosi;
+    spi_cfg.speed = cfg->spi_speed;
+    spi_cfg.mode  = cfg->spi_mode;
+
+    spi_master_open( spi, &spi_cfg );
+
+    digital_out_init( &eth->cs, cfg->cs );
+    digital_out_init( &eth->reset, cfg->rst );
+
+    w5500_cs_pin = cfg->cs;
+    spi_master_deselect_device( w5500_cs_pin );
+
+    eth->spi = spi;
+    memcpy( eth->mac, cfg->mac, 6 );
+    memcpy( &eth->ip, cfg->ip, 4 );
+    eth->fullDuplex = cfg->full_duplex;
+
+    return 0;
+}
+
+// ----------------------------------------------------------------------- END

--- a/tests/spi_ethernet/main.c
+++ b/tests/spi_ethernet/main.c
@@ -2,6 +2,8 @@
 #include "preinit.h"
 #endif
 
+#define SPI_ETH_CHIP    W5500        // Define your chip
+
 #include "spi_ethernet.h"
 #include "drv_spi_master.h"
 #include "log.h"
@@ -10,10 +12,8 @@
 #include <string.h>
 #include <stdint.h>
 
-#define SPI_ETH_CHIP    ENC28J60        // Define your chip
-
 #ifndef MIKROBUS_POSITION_SPI_ETH
-    #define MIKROBUS_POSITION_SPI_ETH 1
+    #define MIKROBUS_POSITION_SPI_ETH 2
 #endif
 
 #define TCP_FLAG_FIN 0x01
@@ -351,12 +351,14 @@ int main( void ) {
     log_printf( &logger, "\r\n" );
 
     // PHY ID
+    #if SPI_ETH_CHIP == ENC28J60
     spi_eth_phy_read( PHHID1, &low, &high );
     phhid1 = ( uint16_t )high << 8 | low;       // 16-bit word reconstruction
     log_printf( &logger, "PHHID1 = 0x%X%X%X%X (expected 0x0083)%s\r\n",
                 ( phhid1 >> 12 ) & 0x0F, ( phhid1 >> 8 ) & 0x0F,
                 ( phhid1 >> 4 ) & 0x0F, phhid1 & 0x0F,
                 ( high == 0x00 && low == 0x83 ) ? "" : " NOT OK" );   // 0x0083 = expected value for the ENC28J60 PHY
+    #endif
 
     // Waiting link
     log_printf( &logger, "\r\nWAIT LINK (10s max)...\r\n" );


### PR DESCRIPTION
## Summary

This PR adds support for the W5500 Ethernet controller by integrating its driver into the existing SPI Ethernet library.