### PR TITLE
Add LAN9250 support to SPI Ethernet library

### DIFF
--- a/middleware/spi_ethernet/lib/CMakeLists.txt
+++ b/middleware/spi_ethernet/lib/CMakeLists.txt
@@ -2,9 +2,11 @@
 mikrosdk_add_library(lib_spi_ethernet MikroSDK.SpiEthernet
     src/spi_ethernet.c
     src/spi_ethernet_enc28j60.c
+    src/spi_ethernet_lan9250.c
 
     include/spi_ethernet.h
     include/spi_ethernet_enc28j60.h
+    include/spi_ethernet_lan9250.h
 )
 
 target_link_libraries(lib_spi_ethernet PUBLIC

--- a/middleware/spi_ethernet/lib/include/spi_ethernet.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet.h
@@ -55,6 +55,8 @@ extern "C"{
 #define ETH_HEADER_SIZE 14
 #define ETH_MAX_PAYLOAD 1500
 #define ETH_MAX_FRAME   ( ETH_HEADER_SIZE + ETH_MAX_PAYLOAD )
+#define ENC28J60        0
+#define LAN9250         2
 
 typedef struct
 {
@@ -400,6 +402,18 @@ typedef struct {
     #define spi_eth_get_rev                             enc28j60_get_rev
     #define spi_eth_phy_read                             enc28j60_phy_read
     typedef enc28j60_cfg_t                              spi_eth_cfg_t;
+#endif
+
+#if SPI_ETH_CHIP == LAN9250
+    #include "spi_ethernet_lan9250.h"
+    extern spi_ethernet_driver_t                        lan9250_driver;
+    extern pin_name_t                                   lan9250_cs_pin;
+    #define SPI_ETH_DRIVER                              lan9250_driver
+    #define SPI_ETH_MAP_MIKROBUS( eth, mikrobus )       LAN9250_MAP_MIKROBUS( eth, mikrobus )
+    #define spi_eth_cfg_setup                           lan9250_cfg_setup
+    #define spi_eth_configure                           lan9250_configure
+    #define spi_eth_get_rev                             lan9250_get_rev
+    typedef lan9250_cfg_t                               spi_eth_cfg_t;
 #endif
 
 #ifdef __cplusplus

--- a/middleware/spi_ethernet/lib/include/spi_ethernet_lan9250.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet_lan9250.h
@@ -1,0 +1,196 @@
+/****************************************************************************
+**
+** Copyright ( C ) ${COPYRIGHT_YEAR} MikroElektronika d.o.o.
+** Contact: https://www.mikroe.com/contact
+**
+** This file is part of the mikroSDK package
+**
+** Commercial License Usage
+**
+** Licensees holding valid commercial NECTO compilers AI licenses may use this
+** file in accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The MikroElektronika Company.
+** For licensing terms and conditions see
+** https://www.mikroe.com/legal/software-license-agreement.
+** For further information use the contact form at
+** https://www.mikroe.com/contact.
+**
+**
+** GNU Lesser General Public License Usage
+**
+** Alternatively, this file may be used for
+** non-commercial projects under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+** OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+** DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+** OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+** OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+****************************************************************************/
+
+/*!
+ * @file spi_ethernet_lan9250.h
+ * @brief SPI Ethernet Microchip LAN9250 Driver.
+ */
+
+#ifndef SPI_ETHERNET_LAN9250_H
+#define SPI_ETHERNET_LAN9250_H
+
+#include "drv_digital_out.h"
+#include "drv_spi_master.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#define LAN9250_MAP_MIKROBUS( cfg, mikrobus ) \
+    cfg.miso  = MIKROBUS( mikrobus, MIKROBUS_MISO ); \
+    cfg.mosi  = MIKROBUS( mikrobus, MIKROBUS_MOSI ); \
+    cfg.sck   = MIKROBUS( mikrobus, MIKROBUS_SCK );  \
+    cfg.cs    = MIKROBUS( mikrobus, MIKROBUS_CS );   \
+    cfg.rst   = MIKROBUS( mikrobus, MIKROBUS_RST );
+
+typedef struct {
+    pin_name_t miso;
+    pin_name_t mosi;
+    pin_name_t sck;
+    pin_name_t cs;
+    pin_name_t rst;
+
+    uint32_t spi_speed;
+    spi_master_mode_t spi_mode;
+
+    uint8_t mac[ 6 ];
+    uint8_t ip[ 4 ];
+    uint8_t full_duplex;
+} lan9250_cfg_t;
+
+/* Forward declarations of driver functions */
+void     lan9250_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv );
+void     lan9250_cfg_setup( lan9250_cfg_t *cfg );
+uint8_t  lan9250_configure( spi_ethernet_t *eth, spi_master_t *spi, lan9250_cfg_t *cfg );
+uint16_t lan9250_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint16_t lan9250_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint8_t  lan9250_packet_available( spi_ethernet_t *eth );
+uint8_t  lan9250_get_link_status( void );
+uint8_t  lan9250_get_rev( void );               // low byte of ID_REV (compat spi_eth_get_rev)
+uint32_t lan9250_get_id_rev( void );            // full 32-bit ID_REV : 0x9250xxxx expected
+int      lan9250_set_mac( uint8_t mac[ 6 ] );
+int      lan9250_get_mac( uint8_t mac[ 6 ] );
+int      lan9250_set_ip( uint8_t ip[ 4 ] );
+int      lan9250_get_ip( uint8_t ip[ 4 ] );
+
+extern spi_ethernet_driver_t lan9250_driver;
+extern pin_name_t            lan9250_cs_pin;
+
+// SPI instructions (datasheet DS00001913, System CSR interface)
+#define LAN9250_SPI_INSTR_READ       0x03   // byte/word/dword read,  no dummy, up to 80 MHz in FASTREAD mode
+#define LAN9250_SPI_INSTR_WRITE      0x02   // byte/word/dword write, no dummy
+#define LAN9250_SPI_INSTR_FASTREAD   0x0B   // 1 dummy byte, not used here
+
+// System CSR registers (byte offsets)
+#define LAN9250_RX_DATA_FIFO   0x0000
+#define LAN9250_TX_DATA_FIFO   0x0020
+#define LAN9250_RX_STATUS_FIFO 0x0040
+#define LAN9250_TX_STATUS_FIFO 0x0048
+#define LAN9250_ID_REV         0x0050
+#define LAN9250_IRQ_CFG        0x0054
+#define LAN9250_INT_STS        0x0058
+#define LAN9250_INT_EN         0x005C
+#define LAN9250_BYTE_TEST      0x0064
+#define LAN9250_RX_CFG         0x006C
+#define LAN9250_TX_CFG         0x0070
+#define LAN9250_HW_CFG         0x0074
+#define LAN9250_RX_DP_CTRL     0x0078
+#define LAN9250_RX_FIFO_INF    0x007C
+#define LAN9250_TX_FIFO_INF    0x0080
+#define LAN9250_MAC_CSR_CMD    0x00A4
+#define LAN9250_MAC_CSR_DATA   0x00A8
+#define LAN9250_RESET_CTL      0x01F8
+
+// BYTE_TEST expected fixed pattern
+#define LAN9250_BYTE_TEST_DEFAULT  0x87654321UL
+
+// HW_CFG bits
+#define LAN9250_HW_CFG_DEVICE_READY  0x08000000UL
+#define LAN9250_HW_CFG_MBO           0x00100000UL   // must-be-one
+#define LAN9250_HW_CFG_TX_FIF_SZ_5KB 0x00050000UL
+
+// TX_CFG bits
+#define LAN9250_TX_CFG_TXSAO  0x00000004UL          // TX status all-ones (host ignores TX status)
+#define LAN9250_TX_CFG_TX_ON  0x00000002UL
+
+// RX_DP_CTRL bits
+#define LAN9250_RX_DP_CTRL_RX_FFWD 0x80000000UL
+
+// RX/TX FIFO information registers
+#define LAN9250_RX_FIFO_INF_RXSUSED 0x00FF0000UL   // number of RX status words available (bits 23:16)
+#define LAN9250_TX_FIFO_INF_TXFREE  0x0000FFFFUL   // free space in TX data FIFO, in bytes
+
+// RESET_CTL bits
+#define LAN9250_RESET_CTL_DIGITAL_RST 0x00000001UL
+
+// ID_REV fields
+#define LAN9250_ID_REV_CHIP_ID_MASK    0xFFFF0000UL
+#define LAN9250_ID_REV_CHIP_ID_LAN9250 0x92500000UL
+
+// TX command 'A' (first DWORD written to TX_DATA_FIFO for a new frame)
+#define LAN9250_TX_CMD_A_BUFFER_ALIGN_4B  0x00000000UL
+#define LAN9250_TX_CMD_A_START_OFFSET_0B  0x00000000UL
+#define LAN9250_TX_CMD_A_FIRST_SEG        0x00002000UL
+#define LAN9250_TX_CMD_A_LAST_SEG         0x00001000UL
+
+// TX command 'B' (second DWORD written to TX_DATA_FIFO)
+#define LAN9250_TX_CMD_B_PACKET_TAG_SHIFT 16
+
+// Number of extra bytes (2 command DWORDs) needed ahead of frame data in TX FIFO
+#define LAN9250_TX_CMD_SIZE  8
+
+// RX status word fields (read from RX_STATUS_FIFO)
+#define LAN9250_RX_STS_ERROR_STATUS  0x00008000UL
+#define LAN9250_RX_STS_PACKET_LEN    0x3FFF0000UL   // bits 29:16
+
+// Host MAC CSR indirect registers (accessed through MAC_CSR_CMD / MAC_CSR_DATA)
+#define LAN9250_HMAC_CR       0x01
+#define LAN9250_HMAC_ADDRH    0x02
+#define LAN9250_HMAC_ADDRL    0x03
+#define LAN9250_HMAC_MII_ACC  0x06
+#define LAN9250_HMAC_MII_DATA 0x07
+
+// MAC_CSR_CMD bits
+#define LAN9250_MAC_CSR_CMD_BUSY  0x80000000UL
+#define LAN9250_MAC_CSR_CMD_READ  0x40000000UL
+#define LAN9250_MAC_CSR_CMD_WRITE 0x00000000UL
+#define LAN9250_MAC_CSR_CMD_ADDR  0x000000FFUL
+
+// HMAC_CR bits
+#define LAN9250_HMAC_CR_RCVOWN 0x00800000UL
+#define LAN9250_HMAC_CR_FDPX   0x00100000UL
+#define LAN9250_HMAC_CR_TXEN   0x00000008UL
+#define LAN9250_HMAC_CR_RXEN   0x00000004UL
+
+// HMAC_MII_ACC bits (PHY register indirect access)
+#define LAN9250_HMAC_MII_ACC_PHY_ADDR_DEFAULT 0x00000800UL   // internal PHY address = 1
+#define LAN9250_HMAC_MII_ACC_MIIRINDA_SHIFT   6
+#define LAN9250_HMAC_MII_ACC_MIIW_R           0x00000002UL   // 1 = write, 0 = read
+#define LAN9250_HMAC_MII_ACC_MIIBZY           0x00000001UL
+
+// PHY registers (through HMAC_MII_ACC/HMAC_MII_DATA)
+#define LAN9250_PHY_BASIC_STATUS 0x01
+
+// PHY_BASIC_STATUS bits
+#define LAN9250_PHY_BASIC_STATUS_LINK_STATUS 0x0004
+
+// Maximum Ethernet frame size handled
+#define LAN9250_FRAME_SIZE 1518
+
+#endif
+
+// ------------------------------------------------------------------------ END

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_lan9250.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_lan9250.c
@@ -1,0 +1,475 @@
+/****************************************************************************
+**
+** Copyright ( C ) ${COPYRIGHT_YEAR} MikroElektronika d.o.o.
+** Contact: https://www.mikroe.com/contact
+**
+** This file is part of the mikroSDK package
+**
+** Commercial License Usage
+**
+** Licensees holding valid commercial NECTO compilers AI licenses may use this
+** file in accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The MikroElektronika Company.
+** For licensing terms and conditions see
+** https://www.mikroe.com/legal/software-license-agreement.
+** For further information use the contact form at
+** https://www.mikroe.com/contact.
+**
+**
+** GNU Lesser General Public License Usage
+**
+** Alternatively, this file may be used for
+** non-commercial projects under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+** OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+** DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+** OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+** OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+****************************************************************************/
+
+/*!
+ * @file spi_ethernet_lan9250.c
+ * @brief SPI Ethernet Microchip LAN9250 Driver.
+ */
+
+#include "spi_ethernet.h"
+#include "spi_ethernet_lan9250.h"
+#include "drv_spi_master.h"
+#include <delays.h>
+#include <string.h>
+
+#define SPI_ETH_OK           0x00
+#define SPI_ETH_INIT_ERROR   0xFF
+
+#define LAN9250_WAIT_TIMEOUT_MS   500
+#define LAN9250_BUSY_TIMEOUT_MS   50
+
+pin_name_t lan9250_cs_pin;
+
+static spi_ethernet_t *current_eth = NULL;
+static uint8_t  lan9250_mac_addr[ 6 ];
+static uint8_t  lan9250_ipaddr[ 4 ];
+static uint32_t lan9250_id_rev;
+
+// Scratch buffer shared by FIFO read/write helpers (avoids large stack usage)
+static uint8_t lan9250_fifo_scratch[ LAN9250_FRAME_SIZE + 4 ];
+
+static uint32_t lan9250_read_sys_reg( uint16_t addr );
+static void     lan9250_write_sys_reg( uint16_t addr, uint32_t val );
+static uint32_t lan9250_read_mac_reg( uint8_t addr );
+static void     lan9250_write_mac_reg( uint8_t addr, uint32_t val );
+static uint16_t lan9250_read_phy_reg( uint8_t addr );
+static void     lan9250_write_phy_reg( uint8_t addr, uint16_t val );
+static void     lan9250_write_fifo( uint16_t addr, uint8_t *buf, uint16_t len );
+static void     lan9250_read_fifo( uint16_t addr, uint8_t *buf, uint16_t copy_len, uint16_t total_len );
+static void     lan9250_hw_reset( spi_ethernet_t *eth );
+static uint8_t  lan9250_wait_ready( void );
+static void     lan9250_drop_packet( uint16_t length );
+
+uint16_t lan9250_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint16_t lan9250_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint8_t  lan9250_packet_available( spi_ethernet_t *eth );
+
+spi_ethernet_driver_t lan9250_driver = {
+    .init            = lan9250_init,
+    .send_packet     = lan9250_send_packet,
+    .read_packet     = lan9250_read_packet,
+    .available       = lan9250_packet_available,
+    .get_link_status = lan9250_get_link_status,
+    .set_mac         = lan9250_set_mac,
+    .get_mac         = lan9250_get_mac,
+    .set_ip          = lan9250_set_ip,
+    .get_ip          = lan9250_get_ip
+};
+
+// Low-level SPI access (System CSR, 32-bit registers, LSB first)
+static uint32_t lan9250_read_sys_reg( uint16_t addr ) {
+    uint8_t hdr[ 3 ];
+    uint8_t buf4[ 4 ] = { 0, 0, 0, 0 };
+
+    hdr[ 0 ] = LAN9250_SPI_INSTR_READ;
+    hdr[ 1 ] = ( uint8_t )( addr >> 8 );
+    hdr[ 2 ] = ( uint8_t )( addr & 0xFF );
+
+    spi_master_select_device( lan9250_cs_pin );
+    spi_master_write_then_read( current_eth->spi, hdr, 3, buf4, 4 );
+    spi_master_deselect_device( lan9250_cs_pin );
+
+    return ( uint32_t )buf4[ 0 ] |
+           ( ( uint32_t )buf4[ 1 ] << 8 ) |
+           ( ( uint32_t )buf4[ 2 ] << 16 ) |
+           ( ( uint32_t )buf4[ 3 ] << 24 );
+}
+
+static void lan9250_write_sys_reg( uint16_t addr, uint32_t val ) {
+    uint8_t hdr[ 3 ];
+    uint8_t buf4[ 4 ];
+
+    hdr[ 0 ] = LAN9250_SPI_INSTR_WRITE;
+    hdr[ 1 ] = ( uint8_t )( addr >> 8 );
+    hdr[ 2 ] = ( uint8_t )( addr & 0xFF );
+
+    buf4[ 0 ] = ( uint8_t )( val & 0xFF );
+    buf4[ 1 ] = ( uint8_t )( ( val >> 8 ) & 0xFF );
+    buf4[ 2 ] = ( uint8_t )( ( val >> 16 ) & 0xFF );
+    buf4[ 3 ] = ( uint8_t )( ( val >> 24 ) & 0xFF );
+
+    spi_master_select_device( lan9250_cs_pin );
+    spi_master_write( current_eth->spi, hdr, 3 );
+    spi_master_write( current_eth->spi, buf4, 4 );
+    spi_master_deselect_device( lan9250_cs_pin );
+}
+
+// Host MAC CSR indirect access (through MAC_CSR_CMD / MAC_CSR_DATA)
+static void lan9250_write_mac_reg( uint8_t addr, uint32_t val ) {
+    uint32_t cmd;
+    uint16_t tries = 0;
+
+    lan9250_write_sys_reg( LAN9250_MAC_CSR_DATA, val );
+
+    cmd = LAN9250_MAC_CSR_CMD_BUSY | LAN9250_MAC_CSR_CMD_WRITE |
+          ( addr & LAN9250_MAC_CSR_CMD_ADDR );
+    lan9250_write_sys_reg( LAN9250_MAC_CSR_CMD, cmd );
+
+    while ( lan9250_read_sys_reg( LAN9250_MAC_CSR_CMD ) & LAN9250_MAC_CSR_CMD_BUSY ) {
+        Delay_ms( 1 );
+        if ( ++tries > LAN9250_BUSY_TIMEOUT_MS ) break;
+    }
+}
+
+static uint32_t lan9250_read_mac_reg( uint8_t addr ) {
+    uint32_t cmd;
+    uint16_t tries = 0;
+
+    cmd = LAN9250_MAC_CSR_CMD_BUSY | LAN9250_MAC_CSR_CMD_READ |
+          ( addr & LAN9250_MAC_CSR_CMD_ADDR );
+    lan9250_write_sys_reg( LAN9250_MAC_CSR_CMD, cmd );
+
+    while ( lan9250_read_sys_reg( LAN9250_MAC_CSR_CMD ) & LAN9250_MAC_CSR_CMD_BUSY ) {
+        Delay_ms( 1 );
+        if ( ++tries > LAN9250_BUSY_TIMEOUT_MS ) break;
+    }
+
+    return lan9250_read_sys_reg( LAN9250_MAC_CSR_DATA );
+}
+
+// PHY register indirect access (through HMAC_MII_ACC / HMAC_MII_DATA)
+static void lan9250_write_phy_reg( uint8_t addr, uint16_t val ) {
+    uint32_t acc;
+    uint16_t tries = 0;
+
+    lan9250_write_mac_reg( LAN9250_HMAC_MII_DATA, val );
+
+    acc = LAN9250_HMAC_MII_ACC_MIIBZY | LAN9250_HMAC_MII_ACC_MIIW_R |
+          LAN9250_HMAC_MII_ACC_PHY_ADDR_DEFAULT |
+          ( ( ( uint32_t )addr << LAN9250_HMAC_MII_ACC_MIIRINDA_SHIFT ) & 0x000007C0UL );
+    lan9250_write_mac_reg( LAN9250_HMAC_MII_ACC, acc );
+
+    while ( lan9250_read_mac_reg( LAN9250_HMAC_MII_ACC ) & LAN9250_HMAC_MII_ACC_MIIBZY ) {
+        Delay_ms( 1 );
+        if ( ++tries > LAN9250_BUSY_TIMEOUT_MS ) break;
+    }
+}
+
+static uint16_t lan9250_read_phy_reg( uint8_t addr ) {
+    uint32_t acc;
+    uint16_t tries = 0;
+
+    acc = LAN9250_HMAC_MII_ACC_MIIBZY | LAN9250_HMAC_MII_ACC_PHY_ADDR_DEFAULT |
+          ( ( ( uint32_t )addr << LAN9250_HMAC_MII_ACC_MIIRINDA_SHIFT ) & 0x000007C0UL );
+    lan9250_write_mac_reg( LAN9250_HMAC_MII_ACC, acc );
+
+    while ( lan9250_read_mac_reg( LAN9250_HMAC_MII_ACC ) & LAN9250_HMAC_MII_ACC_MIIBZY ) {
+        Delay_ms( 1 );
+        if ( ++tries > LAN9250_BUSY_TIMEOUT_MS ) break;
+    }
+
+    return ( uint16_t )( lan9250_read_mac_reg( LAN9250_HMAC_MII_DATA ) & 0xFFFF );
+}
+
+// FIFO burst access (data FIFOs are always accessed in 4-byte words)
+static void lan9250_write_fifo( uint16_t addr, uint8_t *buf, uint16_t len ) {
+    uint8_t hdr[ 3 ];
+    uint16_t aligned_len = ( uint16_t )( ( len + 3 ) & ~( ( uint16_t )3 ) );
+
+    memset( lan9250_fifo_scratch, 0, aligned_len );
+    memcpy( lan9250_fifo_scratch, buf, len );
+
+    hdr[ 0 ] = LAN9250_SPI_INSTR_WRITE;
+    hdr[ 1 ] = ( uint8_t )( addr >> 8 );
+    hdr[ 2 ] = ( uint8_t )( addr & 0xFF );
+
+    spi_master_select_device( lan9250_cs_pin );
+    spi_master_write( current_eth->spi, hdr, 3 );
+    spi_master_write( current_eth->spi, lan9250_fifo_scratch, aligned_len );
+    spi_master_deselect_device( lan9250_cs_pin );
+}
+
+static void lan9250_read_fifo( uint16_t addr, uint8_t *buf, uint16_t copy_len, uint16_t total_len ) {
+    uint8_t hdr[ 3 ];
+    uint16_t aligned_len = ( uint16_t )( ( total_len + 3 ) & ~( ( uint16_t )3 ) );
+
+    hdr[ 0 ] = LAN9250_SPI_INSTR_READ;
+    hdr[ 1 ] = ( uint8_t )( addr >> 8 );
+    hdr[ 2 ] = ( uint8_t )( addr & 0xFF );
+
+    spi_master_select_device( lan9250_cs_pin );
+    spi_master_write_then_read( current_eth->spi, hdr, 3, lan9250_fifo_scratch, aligned_len );
+    spi_master_deselect_device( lan9250_cs_pin );
+
+    memcpy( buf, lan9250_fifo_scratch, copy_len );
+}
+
+// Init
+static void lan9250_hw_reset( spi_ethernet_t *eth ) {
+    digital_out_high( &eth->reset ); Delay_ms( 10 );
+    digital_out_low( &eth->reset );  Delay_ms( 10 );
+    digital_out_high( &eth->reset ); Delay_ms( 50 );
+}
+static uint8_t lan9250_wait_ready( void ) {
+    uint16_t tries = 0;
+
+    while ( lan9250_read_sys_reg( LAN9250_BYTE_TEST ) != LAN9250_BYTE_TEST_DEFAULT ) {
+        Delay_ms( 1 );
+        if ( ++tries > LAN9250_WAIT_TIMEOUT_MS ) return 0;
+    }
+
+    tries = 0;
+    while ( !( lan9250_read_sys_reg( LAN9250_HW_CFG ) & LAN9250_HW_CFG_DEVICE_READY ) ) {
+        Delay_ms( 1 );
+        if ( ++tries > LAN9250_WAIT_TIMEOUT_MS ) return 0;
+    }
+
+    return 1;
+}
+
+void lan9250_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv ) {
+    uint32_t hmac_cr;
+    uint32_t tx_cfg;
+
+    current_eth = eth;
+
+    lan9250_hw_reset( eth );
+
+    // Wait for the SPI interface to become functional
+    lan9250_wait_ready( );
+
+    // Perform a digital (multi-module) reset, then wait again
+    lan9250_write_sys_reg( LAN9250_RESET_CTL, LAN9250_RESET_CTL_DIGITAL_RST );
+    lan9250_wait_ready( );
+
+    // Read chip ID / revision for diagnostics (expected 0x9250xxxx)
+    lan9250_id_rev = lan9250_read_sys_reg( LAN9250_ID_REV );
+
+    memcpy( lan9250_mac_addr, eth->mac, 6 );
+    memcpy( lan9250_ipaddr, &eth->ip, 4 );
+
+    // Configure TX FIFO size (mandatory MBO bit set)
+    lan9250_write_sys_reg( LAN9250_HW_CFG, LAN9250_HW_CFG_MBO | LAN9250_HW_CFG_TX_FIF_SZ_5KB );
+
+    // Ignore TX status words (we poll TX_FIFO_INF instead)
+    lan9250_write_sys_reg( LAN9250_TX_CFG, LAN9250_TX_CFG_TXSAO );
+
+    // Program the MAC address into the hardware filter
+    lan9250_set_mac( lan9250_mac_addr );
+
+    // Configure the host MAC (duplex mode)
+    hmac_cr = eth->fullDuplex ? LAN9250_HMAC_CR_FDPX : 0;
+    lan9250_write_mac_reg( LAN9250_HMAC_CR, hmac_cr );
+
+    // Enable the transmitter at the system level
+    tx_cfg = lan9250_read_sys_reg( LAN9250_TX_CFG );
+    tx_cfg |= LAN9250_TX_CFG_TX_ON;
+    lan9250_write_sys_reg( LAN9250_TX_CFG, tx_cfg );
+
+    // Enable the host MAC transmitter and receiver
+    hmac_cr = lan9250_read_mac_reg( LAN9250_HMAC_CR );
+    hmac_cr |= LAN9250_HMAC_CR_TXEN | LAN9250_HMAC_CR_RXEN;
+    lan9250_write_mac_reg( LAN9250_HMAC_CR, hmac_cr );
+}
+
+// Data transfer
+uint16_t lan9250_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len ) {
+    uint32_t free_space;
+    uint32_t cmd_a;
+    uint32_t cmd_b;
+
+    current_eth = eth;
+
+    free_space = lan9250_read_sys_reg( LAN9250_TX_FIFO_INF ) & LAN9250_TX_FIFO_INF_TXFREE;
+    if ( free_space < ( uint32_t )( len + LAN9250_TX_CMD_SIZE ) )
+        return 0;
+
+    cmd_a = LAN9250_TX_CMD_A_BUFFER_ALIGN_4B | LAN9250_TX_CMD_A_START_OFFSET_0B |
+            LAN9250_TX_CMD_A_FIRST_SEG | LAN9250_TX_CMD_A_LAST_SEG | ( len & 0x000007FFUL );
+    lan9250_write_sys_reg( LAN9250_TX_DATA_FIFO, cmd_a );
+
+    cmd_b = ( ( uint32_t )0 << LAN9250_TX_CMD_B_PACKET_TAG_SHIFT ) | ( len & 0x000007FFUL );
+    lan9250_write_sys_reg( LAN9250_TX_DATA_FIFO, cmd_b );
+
+    lan9250_write_fifo( LAN9250_TX_DATA_FIFO, buf, len );
+
+    return len;
+}
+
+uint8_t lan9250_packet_available( spi_ethernet_t *eth ) {
+    uint32_t rxsused;
+
+    if ( !eth ) return 0;
+
+    rxsused = ( lan9250_read_sys_reg( LAN9250_RX_FIFO_INF ) & LAN9250_RX_FIFO_INF_RXSUSED ) >> 16;
+    return ( uint8_t )( ( rxsused > 0xFF ) ? 0xFF : rxsused );
+}
+
+static void lan9250_drop_packet( uint16_t length ) {
+    uint16_t i;
+    uint16_t tries = 0;
+
+    if ( length >= 16 ) {
+        lan9250_write_sys_reg( LAN9250_RX_DP_CTRL, LAN9250_RX_DP_CTRL_RX_FFWD );
+        while ( lan9250_read_sys_reg( LAN9250_RX_DP_CTRL ) & LAN9250_RX_DP_CTRL_RX_FFWD ) {
+            Delay_ms( 1 );
+            if ( ++tries > LAN9250_BUSY_TIMEOUT_MS ) break;
+        }
+    }
+    else {
+        for ( i = 0; i < length; i += 4 )
+            lan9250_read_sys_reg( LAN9250_RX_DATA_FIFO );
+    }
+}
+
+uint16_t lan9250_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t max_len ) {
+    uint32_t rxsused;
+    uint32_t status;
+    uint16_t length;
+    uint16_t copy_len;
+
+    current_eth = eth;
+
+    rxsused = ( lan9250_read_sys_reg( LAN9250_RX_FIFO_INF ) & LAN9250_RX_FIFO_INF_RXSUSED ) >> 16;
+    if ( rxsused == 0 ) return 0;
+
+    status = lan9250_read_sys_reg( LAN9250_RX_STATUS_FIFO );
+    length = ( uint16_t )( ( status & LAN9250_RX_STS_PACKET_LEN ) >> 16 );
+
+    if ( status & LAN9250_RX_STS_ERROR_STATUS ) {
+        lan9250_drop_packet( length );
+        return 0;
+    }
+
+    if ( length == 0 || length > LAN9250_FRAME_SIZE ) {
+        lan9250_drop_packet( length );
+        return 0;
+    }
+
+    copy_len = ( length > max_len ) ? max_len : length;
+    lan9250_read_fifo( LAN9250_RX_DATA_FIFO, buf, copy_len, length );
+
+    return copy_len;
+}
+
+// Link / identification
+
+uint8_t lan9250_get_link_status( void ) {
+    uint16_t status;
+
+    if ( !current_eth ) return 0;
+
+    /* Any link failure is latched; reading twice returns the actual status */
+    status = lan9250_read_phy_reg( LAN9250_PHY_BASIC_STATUS );
+    status = lan9250_read_phy_reg( LAN9250_PHY_BASIC_STATUS );
+
+    return ( status & LAN9250_PHY_BASIC_STATUS_LINK_STATUS ) ? 1 : 0;
+}
+
+uint8_t lan9250_get_rev( void ) {
+    return ( uint8_t )( lan9250_id_rev & 0xFF );
+}
+
+uint32_t lan9250_get_id_rev( void ) {
+    return lan9250_id_rev;
+}
+
+// Addressing
+int lan9250_set_mac( uint8_t mac[ 6 ] ) {
+    uint32_t addrl;
+    uint32_t addrh;
+
+    memcpy( lan9250_mac_addr, mac, 6 );
+
+    addrl = ( uint32_t )mac[ 0 ] | ( ( uint32_t )mac[ 1 ] << 8 ) |
+            ( ( uint32_t )mac[ 2 ] << 16 ) | ( ( uint32_t )mac[ 3 ] << 24 );
+    addrh = ( uint32_t )mac[ 4 ] | ( ( uint32_t )mac[ 5 ] << 8 );
+
+    lan9250_write_mac_reg( LAN9250_HMAC_ADDRL, addrl );
+    lan9250_write_mac_reg( LAN9250_HMAC_ADDRH, addrh );
+
+    return 1;
+}
+
+int lan9250_get_mac( uint8_t mac[ 6 ] ) {
+    memcpy( mac, lan9250_mac_addr, 6 );
+    return 1;
+}
+
+int lan9250_set_ip( uint8_t ip[ 4 ] ) {
+    memcpy( lan9250_ipaddr, ip, 4 );
+    return 1;
+}
+
+int lan9250_get_ip( uint8_t ip[ 4 ] ) {
+    memcpy( ip, lan9250_ipaddr, 4 );
+    return 1;
+}
+
+// Config / setup
+void lan9250_cfg_setup( lan9250_cfg_t *cfg ) {
+    cfg->miso = HAL_PIN_NC;
+    cfg->mosi = HAL_PIN_NC;
+    cfg->sck  = HAL_PIN_NC;
+    cfg->cs   = HAL_PIN_NC;
+    cfg->rst  = HAL_PIN_NC;
+
+    cfg->spi_speed = 1000000;
+    cfg->spi_mode  = SPI_MASTER_MODE_0;
+
+    cfg->full_duplex = 0;
+}
+
+uint8_t lan9250_configure( spi_ethernet_t *eth, spi_master_t *spi, lan9250_cfg_t *cfg ) {
+    spi_master_config_t spi_cfg;
+    spi_master_configure_default( &spi_cfg );
+
+    spi_cfg.sck   = cfg->sck;
+    spi_cfg.miso  = cfg->miso;
+    spi_cfg.mosi  = cfg->mosi;
+    spi_cfg.speed = cfg->spi_speed;
+    spi_cfg.mode  = cfg->spi_mode;
+
+    spi_master_open( spi, &spi_cfg );
+
+    digital_out_init( &eth->cs, cfg->cs );
+    digital_out_init( &eth->reset, cfg->rst );
+
+    lan9250_cs_pin = cfg->cs;
+    spi_master_deselect_device( lan9250_cs_pin );
+
+    eth->spi = spi;
+    memcpy( eth->mac, cfg->mac, 6 );
+    memcpy( &eth->ip, cfg->ip, 4 );
+    eth->fullDuplex = cfg->full_duplex;
+
+    return 0;
+}
+
+// ----------------------------------------------------------------------- END

--- a/tests/spi_ethernet/main.c
+++ b/tests/spi_ethernet/main.c
@@ -2,6 +2,8 @@
 #include "preinit.h"
 #endif
 
+#define SPI_ETH_CHIP    LAN9250        // Define your chip
+
 #include "spi_ethernet.h"
 #include "drv_spi_master.h"
 #include "log.h"
@@ -10,10 +12,8 @@
 #include <string.h>
 #include <stdint.h>
 
-#define SPI_ETH_CHIP    ENC28J60        // Define your chip
-
 #ifndef MIKROBUS_POSITION_SPI_ETH
-    #define MIKROBUS_POSITION_SPI_ETH 1
+    #define MIKROBUS_POSITION_SPI_ETH 3
 #endif
 
 #define TCP_FLAG_FIN 0x01
@@ -351,12 +351,14 @@ int main( void ) {
     log_printf( &logger, "\r\n" );
 
     // PHY ID
+    #if SPI_ETH_CHIP == ENC28J60
     spi_eth_phy_read( PHHID1, &low, &high );
     phhid1 = ( uint16_t )high << 8 | low;       // 16-bit word reconstruction
     log_printf( &logger, "PHHID1 = 0x%X%X%X%X (expected 0x0083)%s\r\n",
                 ( phhid1 >> 12 ) & 0x0F, ( phhid1 >> 8 ) & 0x0F,
                 ( phhid1 >> 4 ) & 0x0F, phhid1 & 0x0F,
                 ( high == 0x00 && low == 0x83 ) ? "" : " NOT OK" );   // 0x0083 = expected value for the ENC28J60 PHY
+    #endif
 
     // Waiting link
     log_printf( &logger, "\r\nWAIT LINK (10s max)...\r\n" );


### PR DESCRIPTION
This PR adds support for the LAN9250 Ethernet controller by integrating its driver into the existing SPI Ethernet library.