### PR TITLE
Add WIZ-IP55 support to SPI Ethernet library

### DIFF
--- a/middleware/spi_ethernet/lib/include/spi_ethernet.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet.h
@@ -57,6 +57,7 @@ extern "C"{
 #define ETH_MAX_FRAME   ( ETH_HEADER_SIZE + ETH_MAX_PAYLOAD )
 #define ENC28J60        0
 #define W5500           1
+#define WIZ_IP55        W5500
 #define LAN9250         2
 
 typedef struct

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w5500.c
@@ -247,7 +247,12 @@ uint16_t w5500_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t max_len 
 // Link / Identification
 uint8_t w5500_get_link_status( void ) {
     uint8_t phycfgr;
+    uint8_t ver;
     if ( !current_eth ) return 0;
+
+    ver = w5500_read_reg( W5500_VERSIONR, W5500_BSB_COMMON_REG );
+    if ( ver != 0x04 )
+        return 0;
 
     phycfgr = w5500_read_reg( W5500_PHYCFGR, W5500_BSB_COMMON_REG );
     return ( phycfgr & W5500_PHYCFGR_LNK_MASK ) ? 1 : 0;

--- a/tests/spi_ethernet/main.c
+++ b/tests/spi_ethernet/main.c
@@ -2,7 +2,7 @@
 #include "preinit.h"
 #endif
 
-#define SPI_ETH_CHIP    W5500        // Define your chip
+#define SPI_ETH_CHIP    WIZ_IP55        // Define your chip
 
 #include "spi_ethernet.h"
 #include "drv_spi_master.h"
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 #ifndef MIKROBUS_POSITION_SPI_ETH
-    #define MIKROBUS_POSITION_SPI_ETH 2
+    #define MIKROBUS_POSITION_SPI_ETH 1
 #endif
 
 #define TCP_FLAG_FIN 0x01


### PR DESCRIPTION
This PR adds support for the WIZ-IP55 Ethernet controller by integrating its driver into the existing SPI Ethernet library.