### PR TITLE
Add W6100 support to SPI Ethernet library

### DIFF
--- a/middleware/spi_ethernet/lib/CMakeLists.txt
+++ b/middleware/spi_ethernet/lib/CMakeLists.txt
@@ -4,11 +4,13 @@ mikrosdk_add_library(lib_spi_ethernet MikroSDK.SpiEthernet
     src/spi_ethernet_enc28j60.c
     src/spi_ethernet_lan9250.c
     src/spi_ethernet_w5500.c
+    src/spi_ethernet_w6100.c
 
     include/spi_ethernet.h
     include/spi_ethernet_enc28j60.h
     include/spi_ethernet_lan9250.h
     include/spi_ethernet_w5500.h
+    include/spi_ethernet_w6100.h
 )
 
 target_link_libraries(lib_spi_ethernet PUBLIC

--- a/middleware/spi_ethernet/lib/include/spi_ethernet.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet.h
@@ -58,6 +58,7 @@ extern "C"{
 #define ENC28J60        0
 #define W5500           1
 #define LAN9250         2
+#define W6100           3
 
 typedef struct
 {
@@ -423,6 +424,16 @@ typedef struct {
     #define spi_eth_configure                           w5500_configure
     #define spi_eth_get_rev                             w5500_get_rev
     typedef w5500_cfg_t                                 spi_eth_cfg_t;
+#elif SPI_ETH_CHIP == W6100
+    #include "spi_ethernet_w6100.h"
+    extern spi_ethernet_driver_t                        w6100_driver;
+    extern pin_name_t                                   w6100_cs_pin;
+    #define SPI_ETH_DRIVER                              w6100_driver
+    #define SPI_ETH_MAP_MIKROBUS( eth, mikrobus )       W6100_MAP_MIKROBUS( eth, mikrobus )
+    #define spi_eth_cfg_setup                           w6100_cfg_setup
+    #define spi_eth_configure                           w6100_configure
+    #define spi_eth_get_rev                             w6100_get_rev
+    typedef w6100_cfg_t                                 spi_eth_cfg_t; 
 #else
     #error "Unsupported SPI Ethernet chip selected"
 #endif

--- a/middleware/spi_ethernet/lib/include/spi_ethernet_w6100.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet_w6100.h
@@ -81,14 +81,14 @@ uint16_t w6100_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
 uint8_t  w6100_packet_available( spi_ethernet_t *eth );
 uint8_t  w6100_get_link_status( void );
 uint8_t  w6100_get_rev( void );
-uint8_t w6100_reopen_socket0_macraw( void );
+uint8_t  w6100_reopen_socket0_macraw( void );
 int      w6100_set_mac( uint8_t mac[ 6 ] );
 int      w6100_get_mac( uint8_t mac[ 6 ] );
 int      w6100_set_ip( uint8_t ip[ 4 ] );
 int      w6100_get_ip( uint8_t ip[ 4 ] );
 
-extern spi_ethernet_driver_t w6100_driver;
-extern pin_name_t            w6100_cs_pin;
+extern spi_ethernet_driver_t    w6100_driver;
+extern pin_name_t               w6100_cs_pin;
 
 // Control byte: OM (operation mode) bits [1:0]
 #define W6100_OM_VDM        0x00
@@ -107,6 +107,9 @@ extern pin_name_t            w6100_cs_pin;
 // Common register block
 #define W6100_CIDR          0x0000
 #define W6100_VERSIONR      0x0002
+#define W6100_NET4MR        0x4000
+#define W6100_NET4MR_PB     0x01
+#define W6100_NET4MR_RSTB   0x02
 #define W6100_NETMR         0x4008
 #define W6100_SHAR          0x4120
 #define W6100_SUBR          0x4134
@@ -139,7 +142,7 @@ extern pin_name_t            w6100_cs_pin;
 #define W6100_Sn_MR_CLOSED    0x00
 #define W6100_Sn_MR_TCP       0x01
 #define W6100_Sn_MR_UDP       0x02
-#define W6100_Sn_MR_MACRAW    0x04
+#define W6100_Sn_MR_MACRAW    0x07
 #define W6100_Sn_MR_MF        0x40
 /* Sn_CR commands */
 #define W6100_Sn_CR_OPEN      0x01

--- a/middleware/spi_ethernet/lib/include/spi_ethernet_w6100.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet_w6100.h
@@ -1,0 +1,161 @@
+/****************************************************************************
+**
+** Copyright ( C ) ${COPYRIGHT_YEAR} MikroElektronika d.o.o.
+** Contact: https://www.mikroe.com/contact
+**
+** This file is part of the mikroSDK package
+**
+** Commercial License Usage
+**
+** Licensees holding valid commercial NECTO compilers AI licenses may use this
+** file in accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The MikroElektronika Company.
+** For licensing terms and conditions see
+** https://www.mikroe.com/legal/software-license-agreement.
+** For further information use the contact form at
+** https://www.mikroe.com/contact.
+**
+**
+** GNU Lesser General Public License Usage
+**
+** Alternatively, this file may be used for
+** non-commercial projects under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+** OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+** DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+** OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+** OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+****************************************************************************/
+
+/*!
+ * @file spi_ethernet_w6100.h
+ * @brief SPI Ethernet WIZnet W6100 Driver.
+ */
+
+#ifndef SPI_ETHERNET_W6100_H
+#define SPI_ETHERNET_W6100_H
+
+#include "drv_digital_out.h"
+#include "drv_spi_master.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#define W6100_MAP_MIKROBUS( cfg, mikrobus ) \
+    cfg.miso  = MIKROBUS( mikrobus, MIKROBUS_MISO ); \
+    cfg.mosi  = MIKROBUS( mikrobus, MIKROBUS_MOSI ); \
+    cfg.sck   = MIKROBUS( mikrobus, MIKROBUS_SCK );  \
+    cfg.cs    = MIKROBUS( mikrobus, MIKROBUS_CS );   \
+    cfg.rst   = MIKROBUS( mikrobus, MIKROBUS_RST );
+
+typedef struct {
+    pin_name_t miso;
+    pin_name_t mosi;
+    pin_name_t sck;
+    pin_name_t cs;
+    pin_name_t rst;
+
+    uint32_t spi_speed;
+    spi_master_mode_t spi_mode;
+
+    uint8_t mac[ 6 ];
+    uint8_t ip[ 4 ];
+    uint8_t full_duplex;
+} w6100_cfg_t;
+
+// Forward declarations of driver functions
+void     w6100_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv );
+void     w6100_cfg_setup( w6100_cfg_t *cfg );
+uint8_t  w6100_configure( spi_ethernet_t *eth, spi_master_t *spi, w6100_cfg_t *cfg );
+uint16_t w6100_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint16_t w6100_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint8_t  w6100_packet_available( spi_ethernet_t *eth );
+uint8_t  w6100_get_link_status( void );
+uint8_t  w6100_get_rev( void );
+uint8_t w6100_reopen_socket0_macraw( void );
+int      w6100_set_mac( uint8_t mac[ 6 ] );
+int      w6100_get_mac( uint8_t mac[ 6 ] );
+int      w6100_set_ip( uint8_t ip[ 4 ] );
+int      w6100_get_ip( uint8_t ip[ 4 ] );
+
+extern spi_ethernet_driver_t w6100_driver;
+extern pin_name_t            w6100_cs_pin;
+
+// Control byte: OM (operation mode) bits [1:0]
+#define W6100_OM_VDM        0x00
+#define W6100_OM_FDM1       0x01
+#define W6100_OM_FDM2       0x02
+#define W6100_OM_FDM4       0x03
+// Control byte: R/W bit [2]
+#define W6100_RWB_READ      0x00
+#define W6100_RWB_WRITE     0x04
+// Control byte: Block Select Bits [7:3]
+#define W6100_BSB_COMMON_REG        ( 0x00 << 3 )
+#define W6100_BSB_SOCKET0_REG( n )  ( ( ( 1 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+#define W6100_BSB_SOCKET0_TX( n )   ( ( ( 2 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+#define W6100_BSB_SOCKET0_RX( n )   ( ( ( 3 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+
+// Common register block
+#define W6100_CIDR          0x0000
+#define W6100_VERSIONR      0x0002
+#define W6100_NETMR         0x4008
+#define W6100_SHAR          0x4120
+#define W6100_SUBR          0x4134
+#define W6100_SIPR          0x4138
+#define W6100_PHYSR         0x3000
+#define W6100_NETLCKR       0x41F5
+
+// Socket n register block
+#define W6100_Sn_MR           0x0000
+#define W6100_Sn_CR           0x0010
+#define W6100_Sn_IR           0x0020
+#define W6100_Sn_SR           0x0030
+#define W6100_Sn_PORTR        0x0114
+#define W6100_Sn_DHAR         0x0118
+#define W6100_Sn_DIPR         0x0120
+#define W6100_Sn_DPORT        0x0140
+#define W6100_Sn_MSSR         0x0110
+#define W6100_Sn_TOSR         0x0104
+#define W6100_Sn_TTLR         0x0108
+#define W6100_Sn_TX_BSR       0x0200
+#define W6100_Sn_TX_FSR       0x0204
+#define W6100_Sn_TX_RD        0x0208
+#define W6100_Sn_TX_WR        0x020C
+#define W6100_Sn_RX_BSR       0x0220
+#define W6100_Sn_RX_RSR       0x0224
+#define W6100_Sn_RX_RD        0x0228
+#define W6100_Sn_RX_WR        0x022C
+
+/* Sn_MR protocol bits [3:0] */
+#define W6100_Sn_MR_CLOSED    0x00
+#define W6100_Sn_MR_TCP       0x01
+#define W6100_Sn_MR_UDP       0x02
+#define W6100_Sn_MR_MACRAW    0x04
+#define W6100_Sn_MR_MF        0x40
+/* Sn_CR commands */
+#define W6100_Sn_CR_OPEN      0x01
+#define W6100_Sn_CR_CLOSE     0x10
+#define W6100_Sn_CR_SEND      0x20
+#define W6100_Sn_CR_RECV      0x40
+/* Sn_SR values of interest */
+#define W6100_SOCK_CLOSED     0x00
+#define W6100_SOCK_MACRAW     0x42
+
+/* PHYCFGR bits */
+#define W6100_PHYSR_LNK_MASK  0x01
+#define W6100_PHYSR_RST       0x80
+
+#define W6100_FRAME_SIZE 1518
+
+#endif
+
+// ------------------------------------------------------------------------ END

--- a/middleware/spi_ethernet/lib/include/spi_ethernet_w6100.h
+++ b/middleware/spi_ethernet/lib/include/spi_ethernet_w6100.h
@@ -100,9 +100,9 @@ extern pin_name_t               w6100_cs_pin;
 #define W6100_RWB_WRITE     0x04
 // Control byte: Block Select Bits [7:3]
 #define W6100_BSB_COMMON_REG        ( 0x00 << 3 )
-#define W6100_BSB_SOCKET0_REG( n )  ( ( ( 1 + ( 4 * (n) ) ) & 0x1F ) << 3 )
-#define W6100_BSB_SOCKET0_TX( n )   ( ( ( 2 + ( 4 * (n) ) ) & 0x1F ) << 3 )
-#define W6100_BSB_SOCKET0_RX( n )   ( ( ( 3 + ( 4 * (n) ) ) & 0x1F ) << 3 )
+#define W6100_BSB_SOCKET0_REG( n )  ( ( ( 1 + ( 4 * ( n ) ) ) & 0x1F ) << 3 )
+#define W6100_BSB_SOCKET0_TX( n )   ( ( ( 2 + ( 4 * ( n ) ) ) & 0x1F ) << 3 )
+#define W6100_BSB_SOCKET0_RX( n )   ( ( ( 3 + ( 4 * ( n ) ) ) & 0x1F ) << 3 )
 
 // Common register block
 #define W6100_CIDR          0x0000

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w6100.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w6100.c
@@ -213,9 +213,12 @@ void w6100_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv ) {
     w6100_set_mac( w6100_mac_addr );
     w6100_set_ip( w6100_ipaddr );
 
-    w6100_open_socket0_macraw( );   // <-- déplacé ICI, avant le relock
+    w6100_write_reg( W6100_NET4MR, W6100_BSB_COMMON_REG,
+                      W6100_NET4MR_PB | W6100_NET4MR_RSTB );
 
-    w6100_write_reg( W6100_NETLCKR, W6100_BSB_COMMON_REG, 0x00 );   // relock à la fin
+    w6100_open_socket0_macraw( );
+
+    w6100_write_reg( W6100_NETLCKR, W6100_BSB_COMMON_REG, 0x00 );
 }
 
 // Data Tranfert (MACRAW, socket 0)

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w6100.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w6100.c
@@ -1,0 +1,353 @@
+/****************************************************************************
+**
+** Copyright ( C ) ${COPYRIGHT_YEAR} MikroElektronika d.o.o.
+** Contact: https://www.mikroe.com/contact
+**
+** This file is part of the mikroSDK package
+**
+** Commercial License Usage
+**
+** Licensees holding valid commercial NECTO compilers AI licenses may use this
+** file in accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The MikroElektronika Company.
+** For licensing terms and conditions see
+** https://www.mikroe.com/legal/software-license-agreement.
+** For further information use the contact form at
+** https://www.mikroe.com/contact.
+**
+**
+** GNU Lesser General Public License Usage
+**
+** Alternatively, this file may be used for
+** non-commercial projects under the terms of the GNU Lesser
+** General Public License version 3 as published by the Free Software
+** Foundation: https://www.gnu.org/licenses/lgpl-3.0.html.
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+** OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+** DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+** OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+** OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+****************************************************************************/
+
+/*!
+ * @file spi_ethernet_w6100.c
+ * @brief SPI Ethernet WIZnet W6100 Driver.
+ */
+
+#include "spi_ethernet.h"
+#include "spi_ethernet_w6100.h"
+#include "drv_spi_master.h"
+#include <delays.h>
+#include <string.h>
+
+#define SPI_ETH_OK           0x00
+#define SPI_ETH_INIT_ERROR   0xFF
+
+#define W6100_IR_SENDOK      0x10
+
+pin_name_t w6100_cs_pin;
+
+static spi_ethernet_t *current_eth = NULL;
+static uint8_t w6100_mac_addr[ 6 ];
+static uint8_t w6100_ipaddr[ 4 ];
+static uint8_t w6100_hwRev;
+uint8_t dbg_sock_sr;
+uint16_t dbg_send_len;
+uint8_t dbg_send_ir;
+uint8_t dbg_cr_after_open;
+uint8_t dbg_cr_stuck;
+
+static uint8_t   w6100_read_reg( uint16_t addr, uint8_t bsb );
+static void      w6100_write_reg( uint16_t addr, uint8_t bsb, uint8_t val_in );
+static uint16_t  w6100_read_reg16( uint16_t addr, uint8_t bsb );
+static void      w6100_write_reg16( uint16_t addr, uint8_t bsb, uint16_t value );
+static void      w6100_read_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len );
+static void      w6100_write_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len );
+static void      w6100_hw_reset( spi_ethernet_t *eth );
+static void      w6100_wait_socket_cmd( void );
+static void      w6100_open_socket0_macraw( void );
+
+uint16_t w6100_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint16_t w6100_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len );
+uint8_t  w6100_packet_available( spi_ethernet_t *eth );
+
+spi_ethernet_driver_t w6100_driver = {
+    .init            = w6100_init,
+    .send_packet     = w6100_send_packet,
+    .read_packet     = w6100_read_packet,
+    .available       = w6100_packet_available,
+    .get_link_status = w6100_get_link_status,
+    .set_mac         = w6100_set_mac,
+    .get_mac         = w6100_get_mac,
+    .set_ip          = w6100_set_ip,
+    .get_ip          = w6100_get_ip
+};
+
+// Low-Level SPI Access
+static uint8_t w6100_read_reg( uint16_t addr, uint8_t bsb ) {
+    uint8_t header[ 3 ];
+    uint8_t val;
+
+    header[ 0 ] = ( uint8_t )( addr >> 8 );
+    header[ 1 ] = ( uint8_t )( addr & 0xFF );
+    header[ 2 ] = ( uint8_t )( bsb | W6100_RWB_READ | W6100_OM_VDM );
+    val = 0;
+
+    spi_master_select_device( w6100_cs_pin );
+    spi_master_write_then_read( current_eth->spi, header, 3, &val, 1 );
+    spi_master_deselect_device( w6100_cs_pin );
+
+    return val;
+}
+
+static void w6100_write_reg( uint16_t addr, uint8_t bsb, uint8_t val_in ) {
+    uint8_t frame[ 4 ];
+
+    frame[ 0 ] = ( uint8_t )( addr >> 8 );
+    frame[ 1 ] = ( uint8_t )( addr & 0xFF );
+    frame[ 2 ] = ( uint8_t )( bsb | W6100_RWB_WRITE | W6100_OM_VDM );
+    frame[ 3 ] = val_in;
+
+    spi_master_select_device( w6100_cs_pin );
+    spi_master_write( current_eth->spi, frame, 4 );
+    spi_master_deselect_device( w6100_cs_pin );
+}
+
+static uint16_t w6100_read_reg16( uint16_t addr, uint8_t bsb ) {
+    uint8_t buf[ 2 ];
+    w6100_read_burst( addr, bsb, buf, 2 );
+    return ( uint16_t )( ( ( uint16_t )buf[ 0 ] << 8 ) | buf[ 1 ] );
+}
+
+static void w6100_write_reg16( uint16_t addr, uint8_t bsb, uint16_t value ) {
+    uint8_t buf[ 2 ];
+    buf[ 0 ] = ( uint8_t )( value >> 8 );
+    buf[ 1 ] = ( uint8_t )( value & 0xFF );
+    w6100_write_burst( addr, bsb, buf, 2 );
+}
+
+static void w6100_read_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len ) {
+    uint8_t header[ 3 ];
+
+    header[ 0 ] = ( uint8_t )( addr >> 8 );
+    header[ 1 ] = ( uint8_t )( addr & 0xFF );
+    header[ 2 ] = ( uint8_t )( bsb | W6100_RWB_READ | W6100_OM_VDM );
+
+    spi_master_select_device( w6100_cs_pin );
+    spi_master_write_then_read( current_eth->spi, header, 3, buf, len );
+    spi_master_deselect_device( w6100_cs_pin );
+}
+
+static void w6100_write_burst( uint16_t addr, uint8_t bsb, uint8_t *buf, uint16_t len ) {
+    uint8_t header[ 3 ];
+
+    header[ 0 ] = ( uint8_t )( addr >> 8 );
+    header[ 1 ] = ( uint8_t )( addr & 0xFF );
+    header[ 2 ] = ( uint8_t )( bsb | W6100_RWB_WRITE | W6100_OM_VDM );
+
+    spi_master_select_device( w6100_cs_pin );
+    spi_master_write( current_eth->spi, header, 3 );
+    spi_master_write( current_eth->spi, buf, len );
+    spi_master_deselect_device( w6100_cs_pin );
+}
+
+// Init
+static void w6100_hw_reset( spi_ethernet_t *eth ) {
+    digital_out_high( &eth->reset ); Delay_ms( 10 );
+    digital_out_low( &eth->reset );  Delay_ms( 1 );
+    digital_out_high( &eth->reset ); Delay_ms( 100 );
+}
+
+static void w6100_wait_socket_cmd( void ) {
+    uint16_t tries = 0;
+    while ( w6100_read_reg( W6100_Sn_CR, W6100_BSB_SOCKET0_REG( 0 ) ) ) {
+        Delay_ms( 1 );
+        if ( ++tries > 200 ) break;
+    }
+}
+
+static uint8_t w6100_wait_sn_sr_macraw( void ) {
+    uint16_t tries = 0;
+    uint8_t sr;
+    do {
+        sr = w6100_read_reg( W6100_Sn_SR, W6100_BSB_SOCKET0_REG( 0 ) );
+        if ( sr == W6100_SOCK_MACRAW ) return 1;
+        Delay_ms( 1 );
+    } while ( ++tries < 500 );
+    return 0;
+}
+
+static void w6100_open_socket0_macraw( void ) {
+    w6100_write_reg( W6100_Sn_MR, W6100_BSB_SOCKET0_REG( 0 ), W6100_Sn_MR_MACRAW );
+    w6100_write_reg( W6100_Sn_CR, W6100_BSB_SOCKET0_REG( 0 ), W6100_Sn_CR_OPEN );
+
+    dbg_cr_after_open = w6100_read_reg( W6100_Sn_CR, W6100_BSB_SOCKET0_REG( 0 ) );
+    dbg_sock_sr = w6100_wait_sn_sr_macraw( ) ? W6100_SOCK_MACRAW
+                                              : w6100_read_reg( W6100_Sn_SR, W6100_BSB_SOCKET0_REG( 0 ) );
+}
+
+uint8_t w6100_reopen_socket0_macraw( void ) {
+    w6100_open_socket0_macraw();
+    return w6100_read_reg( W6100_Sn_SR, W6100_BSB_SOCKET0_REG( 0 ) );
+}
+
+void w6100_init( spi_ethernet_t *eth, spi_ethernet_driver_t *drv ) {
+    current_eth = eth;
+
+    w6100_hw_reset( eth );
+
+    memcpy( w6100_mac_addr, eth->mac, 6 );
+    memcpy( w6100_ipaddr, &eth->ip, 4 );
+
+    w6100_hwRev = w6100_read_reg( W6100_VERSIONR, W6100_BSB_COMMON_REG );
+
+    w6100_write_reg( W6100_NETLCKR, W6100_BSB_COMMON_REG, 0x3A );
+    w6100_set_mac( w6100_mac_addr );
+    w6100_set_ip( w6100_ipaddr );
+
+    w6100_open_socket0_macraw( );   // <-- déplacé ICI, avant le relock
+
+    w6100_write_reg( W6100_NETLCKR, W6100_BSB_COMMON_REG, 0x00 );   // relock à la fin
+}
+
+// Data Tranfert (MACRAW, socket 0)
+uint16_t w6100_send_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t len ) {
+    uint16_t wr_ptr;
+    current_eth = eth;
+
+    wr_ptr = w6100_read_reg16( W6100_Sn_TX_WR, W6100_BSB_SOCKET0_REG( 0 ) );
+    w6100_write_burst( wr_ptr, W6100_BSB_SOCKET0_TX( 0 ), buf, len );
+    w6100_write_reg16( W6100_Sn_TX_WR, W6100_BSB_SOCKET0_REG( 0 ), ( uint16_t )( wr_ptr + len ) );
+
+    w6100_write_reg( W6100_Sn_CR, W6100_BSB_SOCKET0_REG( 0 ), W6100_Sn_CR_SEND );
+    w6100_wait_socket_cmd( );
+
+    dbg_send_len = len;
+    dbg_send_ir = w6100_read_reg( W6100_Sn_IR, W6100_BSB_SOCKET0_REG( 0 ) );
+
+    w6100_write_reg( W6100_Sn_IR, W6100_BSB_SOCKET0_REG( 0 ), W6100_IR_SENDOK );
+
+    return len;
+}
+
+uint8_t w6100_packet_available( spi_ethernet_t *eth ) {
+    uint16_t rsr;
+    if ( !eth ) return 0;
+
+    rsr = w6100_read_reg16( W6100_Sn_RX_RSR, W6100_BSB_SOCKET0_REG( 0 ) );
+    return ( rsr > 0 ) ? 1 : 0;
+}
+
+uint16_t w6100_read_packet( spi_ethernet_t *eth, uint8_t *buf, uint16_t max_len ) {
+    uint16_t rd_ptr, frame_len, data_len, copy_len;
+    uint8_t hdr[ 2 ];
+    current_eth = eth;
+
+    if ( !w6100_packet_available( eth ) ) return 0;
+
+    rd_ptr = w6100_read_reg16( W6100_Sn_RX_RD, W6100_BSB_SOCKET0_REG( 0 ) );
+
+    w6100_read_burst( rd_ptr, W6100_BSB_SOCKET0_RX( 0 ), hdr, 2 );
+    frame_len = ( uint16_t )( ( ( uint16_t )hdr[ 0 ] << 8 ) | hdr[ 1 ] );
+
+    if ( frame_len < 2 ) {
+        w6100_write_reg16( W6100_Sn_RX_RD, W6100_BSB_SOCKET0_REG( 0 ), ( uint16_t )( rd_ptr + 2 ) );
+        w6100_write_reg( W6100_Sn_CR, W6100_BSB_SOCKET0_REG( 0 ), W6100_Sn_CR_RECV );
+        return 0;
+    }
+
+    data_len = ( uint16_t )( frame_len - 2 );
+    copy_len = ( data_len > max_len ) ? max_len : data_len;
+    w6100_read_burst( ( uint16_t )( rd_ptr + 2 ), W6100_BSB_SOCKET0_RX( 0 ), buf, copy_len );
+
+    w6100_write_reg16( W6100_Sn_RX_RD, W6100_BSB_SOCKET0_REG( 0 ), ( uint16_t )( rd_ptr + frame_len ) );
+    w6100_write_reg( W6100_Sn_CR, W6100_BSB_SOCKET0_REG( 0 ), W6100_Sn_CR_RECV );
+
+    return copy_len;
+}
+
+// Link / Identification
+uint8_t w6100_get_link_status( void ) {
+    uint8_t phycfgr;
+    if ( !current_eth ) return 0;
+
+    phycfgr = w6100_read_reg( W6100_PHYSR, W6100_BSB_COMMON_REG );
+    return ( phycfgr & W6100_PHYSR_LNK_MASK ) ? 1 : 0;
+}
+
+uint8_t w6100_get_rev( void ) {
+    return w6100_hwRev;
+}
+
+// Addressing
+int w6100_set_mac( uint8_t mac[ 6 ] ) {
+    memcpy( w6100_mac_addr, mac, 6 );
+    w6100_write_burst( W6100_SHAR, W6100_BSB_COMMON_REG, mac, 6 );
+    return 1;
+}
+
+int w6100_get_mac( uint8_t mac[ 6 ] ) {
+    memcpy( mac, w6100_mac_addr, 6 );
+    return 1;
+}
+
+int w6100_set_ip( uint8_t ip[ 4 ] ) {
+    memcpy( w6100_ipaddr, ip, 4 );
+    w6100_write_burst( W6100_SIPR, W6100_BSB_COMMON_REG, ip, 4 );
+    return 1;
+}
+
+int w6100_get_ip( uint8_t ip[ 4 ] ) {
+    memcpy( ip, w6100_ipaddr, 4 );
+    return 1;
+}
+
+// Config / Setup
+void w6100_cfg_setup( w6100_cfg_t *cfg ) {
+    cfg->miso = HAL_PIN_NC;
+    cfg->mosi = HAL_PIN_NC;
+    cfg->sck  = HAL_PIN_NC;
+    cfg->cs   = HAL_PIN_NC;
+    cfg->rst  = HAL_PIN_NC;
+
+    cfg->spi_speed = 1000000;
+    cfg->spi_mode  = SPI_MASTER_MODE_0;
+
+    cfg->full_duplex = 0;
+}
+
+uint8_t w6100_configure( spi_ethernet_t *eth, spi_master_t *spi, w6100_cfg_t *cfg ) {
+    spi_master_config_t spi_cfg;
+    spi_master_configure_default( &spi_cfg );
+
+    spi_cfg.sck   = cfg->sck;
+    spi_cfg.miso  = cfg->miso;
+    spi_cfg.mosi  = cfg->mosi;
+    spi_cfg.speed = cfg->spi_speed;
+    spi_cfg.mode  = cfg->spi_mode;
+
+    spi_master_open( spi, &spi_cfg );
+
+    digital_out_init( &eth->cs, cfg->cs );
+    digital_out_init( &eth->reset, cfg->rst );
+
+    w6100_cs_pin = cfg->cs;
+    spi_master_deselect_device( w6100_cs_pin );
+
+    eth->spi = spi;
+    memcpy( eth->mac, cfg->mac, 6 );
+    memcpy( &eth->ip, cfg->ip, 4 );
+    eth->fullDuplex = cfg->full_duplex;
+
+    return 0;
+}
+
+// ----------------------------------------------------------------------- END

--- a/middleware/spi_ethernet/lib/src/spi_ethernet_w6100.c
+++ b/middleware/spi_ethernet/lib/src/spi_ethernet_w6100.c
@@ -195,7 +195,7 @@ static void w6100_open_socket0_macraw( void ) {
 }
 
 uint8_t w6100_reopen_socket0_macraw( void ) {
-    w6100_open_socket0_macraw();
+    w6100_open_socket0_macraw( );
     return w6100_read_reg( W6100_Sn_SR, W6100_BSB_SOCKET0_REG( 0 ) );
 }
 

--- a/tests/spi_ethernet/main.c
+++ b/tests/spi_ethernet/main.c
@@ -2,7 +2,7 @@
 #include "preinit.h"
 #endif
 
-#define SPI_ETH_CHIP    W5500        // Define your chip
+#define SPI_ETH_CHIP    W6100        // Define your chip
 
 #include "spi_ethernet.h"
 #include "drv_spi_master.h"
@@ -13,7 +13,7 @@
 #include <stdint.h>
 
 #ifndef MIKROBUS_POSITION_SPI_ETH
-    #define MIKROBUS_POSITION_SPI_ETH 2
+    #define MIKROBUS_POSITION_SPI_ETH 1
 #endif
 
 #define TCP_FLAG_FIN 0x01


### PR DESCRIPTION
This PR adds support for the W6100 Ethernet controller by integrating its driver into the existing SPI Ethernet library.